### PR TITLE
6.2.0 seller removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ you will need internet access for a successful build.
 
 * In order to open the client library in Eclipse click on `File -> Import`.
 
-![Importing SDK into Eclipse - Step 1](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=import0)
+![Importing SDK into Eclipse - Step 1](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=import0)
 
 * In the import dialog, select `Existing Java Project` and click `Next`.
 
-![Importing SDK into Eclipse - Step 2](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=import1)
+![Importing SDK into Eclipse - Step 2](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=import1)
 
 * Browse to locate the folder containing the source code. Select the detected location of the project and click `Finish`.
 
-![Importing SDK into Eclipse - Step 3](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=import2)
+![Importing SDK into Eclipse - Step 3](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=import2)
 
 * Upon successful import, the project will be automatically built by Eclipse after automatically resolving the dependencies.
 
-![Importing SDK into Eclipse - Step 4](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=import3)
+![Importing SDK into Eclipse - Step 4](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=import3)
 
 ## Installation
 
@@ -36,35 +36,35 @@ The following section explains how to use the PagarmeApiSDKLib library in a new 
 
 For starting a new project, click the menu command `File > New > Project`.
 
-![Add a new project in Eclipse](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=createNewProject0)
+![Add a new project in Eclipse](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=createNewProject0)
 
 Next, choose `Maven > Maven Project` and click `Next`.
 
-![Create a new Maven Project - Step 1](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=createNewProject1)
+![Create a new Maven Project - Step 1](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=createNewProject1)
 
 Here, make sure to use the current workspace by choosing `Use default Workspace location`, as shown in the picture below and click `Next`.
 
-![Create a new Maven Project - Step 2](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=createNewProject2)
+![Create a new Maven Project - Step 2](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=createNewProject2)
 
 Following this, select the *quick start* project type to create a simple project with an existing class and a `main` method. To do this, choose `maven-archetype-quickstart` item from the list and click `Next`.
 
-![Create a new Maven Project - Step 3](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=createNewProject3)
+![Create a new Maven Project - Step 3](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=createNewProject3)
 
 In the last step, provide a `Group Id` and `Artifact Id` as shown in the picture below and click `Finish`.
 
-![Create a new Maven Project - Step 4](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=createNewProject4)
+![Create a new Maven Project - Step 4](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=createNewProject4)
 
 ### 2. Add reference of the library project
 
 The created Maven project manages its dependencies using its `pom.xml` file. In order to add a dependency on the *PagarmeApiSDKLib* client library, double click on the `pom.xml` file in the `Package Explorer`. Opening the `pom.xml` file will render a graphical view on the canvas. Here, switch to the `Dependencies` tab and click the `Add` button as shown in the picture below.
 
-![Adding dependency to the client library - Step 1](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=testProject0)
+![Adding dependency to the client library - Step 1](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=testProject0)
 
-Clicking the `Add` button will open a dialog where you need to specify PagarmeApiSDKLib in `Group Id`, pagarme-api-sdklib in `Artifact Id` and 6.1.0-alpha in the `Version` fields. Once added click `OK`. Save the `pom.xml` file.
+Clicking the `Add` button will open a dialog where you need to specify PagarmeApiSDKLib in `Group Id`, pagarme-api-sdklib in `Artifact Id` and 6.2.0 in the `Version` fields. Once added click `OK`. Save the `pom.xml` file.
 
-![Adding dependency to the client library - Step 2](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=testProject1)
+![Adding dependency to the client library - Step 2](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=testProject1)
 
-![Adding sample code](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.1.0-alpha&step=testProject2)
+![Adding sample code](https://apidocs.io/illustration/java?workspaceFolder=PagarmeApiSDK-Java&workspaceName=PagarmeApiSDK&projectName=PagarmeApiSDKLib&rootNamespace=me.pagar.api&groupId=PagarmeApiSDKLib&artifactId=pagarme-api-sdklib&version=6.2.0&step=testProject2)
 
 ### 3. Write sample code
 
@@ -79,7 +79,7 @@ The following parameters are configurable for the API Client:
 
 | Parameter | Type | Description |
 |  --- | --- | --- |
-| `httpClientConfig` | `ReadonlyHttpClientConfiguration` | Http Client Configuration instance.<br>* See available [builder methods here](/doc/http-client-configuration-builder.md). |
+| `httpClientConfig` | `ReadonlyHttpClientConfiguration` | Http Client Configuration instance. |
 | `basicAuthUserName` | `String` | The username to use with basic authentication |
 | `basicAuthPassword` | `String` | The password to use with basic authentication |
 
@@ -120,7 +120,6 @@ Here is the list of errors that the API might throw.
 * [Charges](/doc/controllers/charges.md)
 * [Recipients](/doc/controllers/recipients.md)
 * [Tokens](/doc/controllers/tokens.md)
-* [Sellers](/doc/controllers/sellers.md)
 * [Transactions](/doc/controllers/transactions.md)
 * [Transfers](/doc/controllers/transfers.md)
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -5,7 +5,7 @@ The following parameters are configurable for the API Client:
 
 | Parameter | Type | Description |
 |  --- | --- | --- |
-| `httpClientConfig` | `ReadonlyHttpClientConfiguration` | Http Client Configuration instance.<br>* See available [builder methods here](/doc/http-client-configuration-builder.md). |
+| `httpClientConfig` | `ReadonlyHttpClientConfiguration` | Http Client Configuration instance. |
 | `basicAuthUserName` | `String` | The username to use with basic authentication |
 | `basicAuthPassword` | `String` | The password to use with basic authentication |
 
@@ -27,16 +27,15 @@ The gateway for the SDK. This class acts as a factory for the Controllers and al
 
 | Name | Description | Return Type |
 |  --- | --- | --- |
+| `getOrdersController()` | Provides access to Orders controller. | `OrdersController` |
 | `getPlansController()` | Provides access to Plans controller. | `PlansController` |
 | `getSubscriptionsController()` | Provides access to Subscriptions controller. | `SubscriptionsController` |
 | `getInvoicesController()` | Provides access to Invoices controller. | `InvoicesController` |
-| `getOrdersController()` | Provides access to Orders controller. | `OrdersController` |
 | `getCustomersController()` | Provides access to Customers controller. | `CustomersController` |
 | `getRecipientsController()` | Provides access to Recipients controller. | `RecipientsController` |
 | `getChargesController()` | Provides access to Charges controller. | `ChargesController` |
-| `getTransfersController()` | Provides access to Transfers controller. | `TransfersController` |
 | `getTokensController()` | Provides access to Tokens controller. | `TokensController` |
-| `getSellersController()` | Provides access to Sellers controller. | `SellersController` |
+| `getTransfersController()` | Provides access to Transfers controller. | `TransfersController` |
 | `getTransactionsController()` | Provides access to Transactions controller. | `TransactionsController` |
 
 ### Methods

--- a/doc/configuration-interface.md
+++ b/doc/configuration-interface.md
@@ -8,7 +8,7 @@ This is the base class for all exceptions that represent an error response from 
 | Name | Description | Return Type |
 |  --- | --- | --- |
 | `getEnvironment()` | Current API environment. | `Environment` |
-| `getHttpClientConfig()` | Http Client Configuration instance.<br>* See available [builder methods here](/doc/http-client-configuration-builder.md). | `ReadonlyHttpClientConfiguration` |
+| `getHttpClientConfig()` | Http Client Configuration instance. | `ReadonlyHttpClientConfiguration` |
 | `getBaseUri(Server server)` | Get base URI by current environment. | `String` |
 | `getBaseUri()` | Get base URI by current environment. | `String` |
 

--- a/doc/controllers/charges.md
+++ b/doc/controllers/charges.md
@@ -12,17 +12,17 @@ ChargesController chargesController = client.getChargesController();
 
 * [Update Charge Metadata](/doc/controllers/charges.md#update-charge-metadata)
 * [Update Charge Payment Method](/doc/controllers/charges.md#update-charge-payment-method)
-* [Get Charge Transactions](/doc/controllers/charges.md#get-charge-transactions)
-* [Update Charge Due Date](/doc/controllers/charges.md#update-charge-due-date)
-* [Get Charges](/doc/controllers/charges.md#get-charges)
-* [Capture Charge](/doc/controllers/charges.md#capture-charge)
 * [Update Charge Card](/doc/controllers/charges.md#update-charge-card)
-* [Get Charge](/doc/controllers/charges.md#get-charge)
 * [Get Charges Summary](/doc/controllers/charges.md#get-charges-summary)
-* [Retry Charge](/doc/controllers/charges.md#retry-charge)
-* [Cancel Charge](/doc/controllers/charges.md#cancel-charge)
 * [Create Charge](/doc/controllers/charges.md#create-charge)
+* [Get Charge Transactions](/doc/controllers/charges.md#get-charge-transactions)
+* [Capture Charge](/doc/controllers/charges.md#capture-charge)
+* [Get Charge](/doc/controllers/charges.md#get-charge)
+* [Cancel Charge](/doc/controllers/charges.md#cancel-charge)
+* [Get Charges](/doc/controllers/charges.md#get-charges)
 * [Confirm Payment](/doc/controllers/charges.md#confirm-payment)
+* [Update Charge Due Date](/doc/controllers/charges.md#update-charge-due-date)
+* [Retry Charge](/doc/controllers/charges.md#retry-charge)
 
 
 # Update Charge Metadata
@@ -137,167 +137,6 @@ try {
 ```
 
 
-# Get Charge Transactions
-
-```java
-CompletableFuture<ListChargeTransactionsResponse> getChargeTransactions(
-    final String chargeId,
-    final Integer page,
-    final Integer size)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `String` | Template, Required | Charge Id |
-| `page` | `Integer` | Query, Optional | Page number |
-| `size` | `Integer` | Query, Optional | Page size |
-
-## Response Type
-
-[`ListChargeTransactionsResponse`](/doc/models/list-charge-transactions-response.md)
-
-## Example Usage
-
-```java
-String chargeId = "charge_id8";
-
-try {
-    ListChargeTransactionsResponse response = chargesController.getChargeTransactions(chargeId, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Charge Due Date
-
-Updates the due date from a charge
-
-```java
-CompletableFuture<GetChargeResponse> updateChargeDueDate(
-    final String chargeId,
-    final UpdateChargeDueDateRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `String` | Template, Required | Charge Id |
-| `request` | [`UpdateChargeDueDateRequest`](/doc/models/update-charge-due-date-request.md) | Body, Required | Request for updating the due date |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```java
-String chargeId = "charge_id8";
-UpdateChargeDueDateRequest request = new UpdateChargeDueDateRequest();
-
-try {
-    GetChargeResponse response = chargesController.updateChargeDueDate(chargeId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Charges
-
-Lists all charges
-
-```java
-CompletableFuture<ListChargesResponse> getCharges(
-    final Integer page,
-    final Integer size,
-    final String code,
-    final String status,
-    final String paymentMethod,
-    final String customerId,
-    final String orderId,
-    final LocalDateTime createdSince,
-    final LocalDateTime createdUntil)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `page` | `Integer` | Query, Optional | Page number |
-| `size` | `Integer` | Query, Optional | Page size |
-| `code` | `String` | Query, Optional | Filter for charge's code |
-| `status` | `String` | Query, Optional | Filter for charge's status |
-| `paymentMethod` | `String` | Query, Optional | Filter for charge's payment method |
-| `customerId` | `String` | Query, Optional | Filter for charge's customer id |
-| `orderId` | `String` | Query, Optional | Filter for charge's order id |
-| `createdSince` | `LocalDateTime` | Query, Optional | Filter for the beginning of the range for charge's creation |
-| `createdUntil` | `LocalDateTime` | Query, Optional | Filter for the end of the range for charge's creation |
-
-## Response Type
-
-[`ListChargesResponse`](/doc/models/list-charges-response.md)
-
-## Example Usage
-
-```java
-try {
-    ListChargesResponse response = chargesController.getCharges(null, null, null, null, null, null, null, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Capture Charge
-
-Captures a charge
-
-```java
-CompletableFuture<GetChargeResponse> captureCharge(
-    final String chargeId,
-    final CreateCaptureChargeRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `String` | Template, Required | Charge id |
-| `request` | [`CreateCaptureChargeRequest`](/doc/models/create-capture-charge-request.md) | Body, Optional | Request for capturing a charge |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```java
-String chargeId = "charge_id8";
-
-try {
-    GetChargeResponse response = chargesController.captureCharge(chargeId, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
 # Update Charge Card
 
 Updates the card from a charge
@@ -370,40 +209,6 @@ try {
 ```
 
 
-# Get Charge
-
-Get a charge from its id
-
-```java
-CompletableFuture<GetChargeResponse> getCharge(
-    final String chargeId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `String` | Template, Required | Charge id |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```java
-String chargeId = "charge_id8";
-
-try {
-    GetChargeResponse response = chargesController.getCharge(chargeId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
 # Get Charges Summary
 
 ```java
@@ -432,80 +237,6 @@ String status = "status8";
 
 try {
     GetChargesSummaryResponse response = chargesController.getChargesSummary(status, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Retry Charge
-
-Retries a charge
-
-```java
-CompletableFuture<GetChargeResponse> retryCharge(
-    final String chargeId,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `String` | Template, Required | Charge id |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```java
-String chargeId = "charge_id8";
-
-try {
-    GetChargeResponse response = chargesController.retryCharge(chargeId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Cancel Charge
-
-Cancel a charge
-
-```java
-CompletableFuture<GetChargeResponse> cancelCharge(
-    final String chargeId,
-    final CreateCancelChargeRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `String` | Template, Required | Charge id |
-| `request` | [`CreateCancelChargeRequest`](/doc/models/create-cancel-charge-request.md) | Body, Optional | Request for cancelling a charge |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetChargeResponse`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```java
-String chargeId = "charge_id8";
-
-try {
-    GetChargeResponse response = chargesController.cancelCharge(chargeId, null, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -588,6 +319,200 @@ try {
 ```
 
 
+# Get Charge Transactions
+
+```java
+CompletableFuture<ListChargeTransactionsResponse> getChargeTransactions(
+    final String chargeId,
+    final Integer page,
+    final Integer size)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `String` | Template, Required | Charge Id |
+| `page` | `Integer` | Query, Optional | Page number |
+| `size` | `Integer` | Query, Optional | Page size |
+
+## Response Type
+
+[`ListChargeTransactionsResponse`](/doc/models/list-charge-transactions-response.md)
+
+## Example Usage
+
+```java
+String chargeId = "charge_id8";
+
+try {
+    ListChargeTransactionsResponse response = chargesController.getChargeTransactions(chargeId, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Capture Charge
+
+Captures a charge
+
+```java
+CompletableFuture<GetChargeResponse> captureCharge(
+    final String chargeId,
+    final CreateCaptureChargeRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `String` | Template, Required | Charge id |
+| `request` | [`CreateCaptureChargeRequest`](/doc/models/create-capture-charge-request.md) | Body, Optional | Request for capturing a charge |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```java
+String chargeId = "charge_id8";
+
+try {
+    GetChargeResponse response = chargesController.captureCharge(chargeId, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Charge
+
+Get a charge from its id
+
+```java
+CompletableFuture<GetChargeResponse> getCharge(
+    final String chargeId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `String` | Template, Required | Charge id |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```java
+String chargeId = "charge_id8";
+
+try {
+    GetChargeResponse response = chargesController.getCharge(chargeId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Cancel Charge
+
+Cancel a charge
+
+```java
+CompletableFuture<GetChargeResponse> cancelCharge(
+    final String chargeId,
+    final CreateCancelChargeRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `String` | Template, Required | Charge id |
+| `request` | [`CreateCancelChargeRequest`](/doc/models/create-cancel-charge-request.md) | Body, Optional | Request for cancelling a charge |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```java
+String chargeId = "charge_id8";
+
+try {
+    GetChargeResponse response = chargesController.cancelCharge(chargeId, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Charges
+
+Lists all charges
+
+```java
+CompletableFuture<ListChargesResponse> getCharges(
+    final Integer page,
+    final Integer size,
+    final String code,
+    final String status,
+    final String paymentMethod,
+    final String customerId,
+    final String orderId,
+    final LocalDateTime createdSince,
+    final LocalDateTime createdUntil)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `page` | `Integer` | Query, Optional | Page number |
+| `size` | `Integer` | Query, Optional | Page size |
+| `code` | `String` | Query, Optional | Filter for charge's code |
+| `status` | `String` | Query, Optional | Filter for charge's status |
+| `paymentMethod` | `String` | Query, Optional | Filter for charge's payment method |
+| `customerId` | `String` | Query, Optional | Filter for charge's customer id |
+| `orderId` | `String` | Query, Optional | Filter for charge's order id |
+| `createdSince` | `LocalDateTime` | Query, Optional | Filter for the beginning of the range for charge's creation |
+| `createdUntil` | `LocalDateTime` | Query, Optional | Filter for the end of the range for charge's creation |
+
+## Response Type
+
+[`ListChargesResponse`](/doc/models/list-charges-response.md)
+
+## Example Usage
+
+```java
+try {
+    ListChargesResponse response = chargesController.getCharges(null, null, null, null, null, null, null, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
 # Confirm Payment
 
 ```java
@@ -616,6 +541,81 @@ String chargeId = "charge_id8";
 
 try {
     GetChargeResponse response = chargesController.confirmPayment(chargeId, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Charge Due Date
+
+Updates the due date from a charge
+
+```java
+CompletableFuture<GetChargeResponse> updateChargeDueDate(
+    final String chargeId,
+    final UpdateChargeDueDateRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `String` | Template, Required | Charge Id |
+| `request` | [`UpdateChargeDueDateRequest`](/doc/models/update-charge-due-date-request.md) | Body, Required | Request for updating the due date |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```java
+String chargeId = "charge_id8";
+UpdateChargeDueDateRequest request = new UpdateChargeDueDateRequest();
+
+try {
+    GetChargeResponse response = chargesController.updateChargeDueDate(chargeId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Retry Charge
+
+Retries a charge
+
+```java
+CompletableFuture<GetChargeResponse> retryCharge(
+    final String chargeId,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `String` | Template, Required | Charge id |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetChargeResponse`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```java
+String chargeId = "charge_id8";
+
+try {
+    GetChargeResponse response = chargesController.retryCharge(chargeId, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/controllers/customers.md
+++ b/doc/controllers/customers.md
@@ -13,24 +13,24 @@ CustomersController customersController = client.getCustomersController();
 * [Update Card](/doc/controllers/customers.md#update-card)
 * [Update Address](/doc/controllers/customers.md#update-address)
 * [Delete Access Token](/doc/controllers/customers.md#delete-access-token)
-* [Create Customer](/doc/controllers/customers.md#create-customer)
 * [Create Address](/doc/controllers/customers.md#create-address)
-* [Delete Access Tokens](/doc/controllers/customers.md#delete-access-tokens)
-* [Get Address](/doc/controllers/customers.md#get-address)
-* [Delete Address](/doc/controllers/customers.md#delete-address)
+* [Create Customer](/doc/controllers/customers.md#create-customer)
 * [Create Card](/doc/controllers/customers.md#create-card)
-* [Get Customers](/doc/controllers/customers.md#get-customers)
-* [Update Customer](/doc/controllers/customers.md#update-customer)
-* [Create Access Token](/doc/controllers/customers.md#create-access-token)
-* [Get Access Tokens](/doc/controllers/customers.md#get-access-tokens)
 * [Get Cards](/doc/controllers/customers.md#get-cards)
 * [Renew Card](/doc/controllers/customers.md#renew-card)
+* [Get Address](/doc/controllers/customers.md#get-address)
+* [Delete Address](/doc/controllers/customers.md#delete-address)
 * [Get Access Token](/doc/controllers/customers.md#get-access-token)
 * [Update Customer Metadata](/doc/controllers/customers.md#update-customer-metadata)
+* [Get Card](/doc/controllers/customers.md#get-card)
+* [Delete Access Tokens](/doc/controllers/customers.md#delete-access-tokens)
+* [Create Access Token](/doc/controllers/customers.md#create-access-token)
+* [Get Access Tokens](/doc/controllers/customers.md#get-access-tokens)
+* [Get Customers](/doc/controllers/customers.md#get-customers)
+* [Update Customer](/doc/controllers/customers.md#update-customer)
 * [Delete Card](/doc/controllers/customers.md#delete-card)
 * [Get Addresses](/doc/controllers/customers.md#get-addresses)
 * [Get Customer](/doc/controllers/customers.md#get-customer)
-* [Get Card](/doc/controllers/customers.md#get-card)
 
 
 # Update Card
@@ -182,63 +182,6 @@ try {
 ```
 
 
-# Create Customer
-
-Creates a new customer
-
-```java
-CompletableFuture<GetCustomerResponse> createCustomer(
-    final CreateCustomerRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `request` | [`CreateCustomerRequest`](/doc/models/create-customer-request.md) | Body, Required | Request for creating a customer |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetCustomerResponse`](/doc/models/get-customer-response.md)
-
-## Example Usage
-
-```java
-CreateCustomerRequest request = new CreateCustomerRequest();
-request.setName("{\\n    \"name\": \"Tony Stark\"\\n}");
-request.setEmail("email0");
-request.setDocument("document0");
-request.setType("type4");
-request.setAddress(new CreateAddressRequest());
-request.getAddress().setStreet("street2");
-request.getAddress().setNumber("number0");
-request.getAddress().setZipCode("zip_code6");
-request.getAddress().setNeighborhood("neighborhood8");
-request.getAddress().setCity("city2");
-request.getAddress().setState("state8");
-request.getAddress().setCountry("country6");
-request.getAddress().setComplement("complement8");
-request.getAddress().setMetadata(new LinkedHashMap<>());
-request.getAddress().getMetadata().put("key0", "metadata7");
-request.getAddress().setLine1("line_16");
-request.getAddress().setLine2("line_20");
-request.setMetadata(new LinkedHashMap<>());
-request.getMetadata().put("key0", "metadata3");
-request.setPhones(new CreatePhonesRequest());
-request.setCode("code4");
-
-try {
-    GetCustomerResponse response = customersController.createCustomer(request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
 # Create Address
 
 Creates a new address for a customer
@@ -290,85 +233,13 @@ try {
 ```
 
 
-# Delete Access Tokens
+# Create Customer
 
-Delete a Customer's access tokens
-
-```java
-CompletableFuture<ListAccessTokensResponse> deleteAccessTokens(
-    final String customerId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `String` | Template, Required | Customer Id |
-
-## Response Type
-
-[`ListAccessTokensResponse`](/doc/models/list-access-tokens-response.md)
-
-## Example Usage
+Creates a new customer
 
 ```java
-String customerId = "customer_id8";
-
-try {
-    ListAccessTokensResponse response = customersController.deleteAccessTokens(customerId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Address
-
-Get a customer's address
-
-```java
-CompletableFuture<GetAddressResponse> getAddress(
-    final String customerId,
-    final String addressId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `String` | Template, Required | Customer id |
-| `addressId` | `String` | Template, Required | Address Id |
-
-## Response Type
-
-[`GetAddressResponse`](/doc/models/get-address-response.md)
-
-## Example Usage
-
-```java
-String customerId = "customer_id8";
-String addressId = "address_id0";
-
-try {
-    GetAddressResponse response = customersController.getAddress(customerId, addressId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Delete Address
-
-Delete a Customer's address
-
-```java
-CompletableFuture<GetAddressResponse> deleteAddress(
-    final String customerId,
-    final String addressId,
+CompletableFuture<GetCustomerResponse> createCustomer(
+    final CreateCustomerRequest request,
     final String idempotencyKey)
 ```
 
@@ -376,22 +247,41 @@ CompletableFuture<GetAddressResponse> deleteAddress(
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `customerId` | `String` | Template, Required | Customer Id |
-| `addressId` | `String` | Template, Required | Address Id |
+| `request` | [`CreateCustomerRequest`](/doc/models/create-customer-request.md) | Body, Required | Request for creating a customer |
 | `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
 
-[`GetAddressResponse`](/doc/models/get-address-response.md)
+[`GetCustomerResponse`](/doc/models/get-customer-response.md)
 
 ## Example Usage
 
 ```java
-String customerId = "customer_id8";
-String addressId = "address_id0";
+CreateCustomerRequest request = new CreateCustomerRequest();
+request.setName("{\\n    \"name\": \"Tony Stark\"\\n}");
+request.setEmail("email0");
+request.setDocument("document0");
+request.setType("type4");
+request.setAddress(new CreateAddressRequest());
+request.getAddress().setStreet("street2");
+request.getAddress().setNumber("number0");
+request.getAddress().setZipCode("zip_code6");
+request.getAddress().setNeighborhood("neighborhood8");
+request.getAddress().setCity("city2");
+request.getAddress().setState("state8");
+request.getAddress().setCountry("country6");
+request.getAddress().setComplement("complement8");
+request.getAddress().setMetadata(new LinkedHashMap<>());
+request.getAddress().getMetadata().put("key0", "metadata7");
+request.getAddress().setLine1("line_16");
+request.getAddress().setLine2("line_20");
+request.setMetadata(new LinkedHashMap<>());
+request.getMetadata().put("key0", "metadata3");
+request.setPhones(new CreatePhonesRequest());
+request.setCode("code4");
 
 try {
-    GetAddressResponse response = customersController.deleteAddress(customerId, addressId, null);
+    GetCustomerResponse response = customersController.createCustomer(request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -459,167 +349,6 @@ request.setLabel("label6");
 
 try {
     GetCardResponse response = customersController.createCard(customerId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Customers
-
-Get all Customers
-
-```java
-CompletableFuture<ListCustomersResponse> getCustomers(
-    final String name,
-    final String document,
-    final Integer page,
-    final Integer size,
-    final String email,
-    final String code)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `name` | `String` | Query, Optional | Name of the Customer |
-| `document` | `String` | Query, Optional | Document of the Customer |
-| `page` | `Integer` | Query, Optional | Current page the the search<br>**Default**: `1` |
-| `size` | `Integer` | Query, Optional | Quantity pages of the search<br>**Default**: `10` |
-| `email` | `String` | Query, Optional | Customer's email |
-| `code` | `String` | Query, Optional | Customer's code |
-
-## Response Type
-
-[`ListCustomersResponse`](/doc/models/list-customers-response.md)
-
-## Example Usage
-
-```java
-Integer page = 1;
-Integer size = 10;
-
-try {
-    ListCustomersResponse response = customersController.getCustomers(null, null, page, size, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Customer
-
-Updates a customer
-
-```java
-CompletableFuture<GetCustomerResponse> updateCustomer(
-    final String customerId,
-    final UpdateCustomerRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `String` | Template, Required | Customer id |
-| `request` | [`UpdateCustomerRequest`](/doc/models/update-customer-request.md) | Body, Required | Request for updating a customer |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetCustomerResponse`](/doc/models/get-customer-response.md)
-
-## Example Usage
-
-```java
-String customerId = "customer_id8";
-UpdateCustomerRequest request = new UpdateCustomerRequest();
-
-try {
-    GetCustomerResponse response = customersController.updateCustomer(customerId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Create Access Token
-
-Creates a access token for a customer
-
-```java
-CompletableFuture<GetAccessTokenResponse> createAccessToken(
-    final String customerId,
-    final CreateAccessTokenRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `String` | Template, Required | Customer Id |
-| `request` | [`CreateAccessTokenRequest`](/doc/models/create-access-token-request.md) | Body, Required | Request for creating a access token |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetAccessTokenResponse`](/doc/models/get-access-token-response.md)
-
-## Example Usage
-
-```java
-String customerId = "customer_id8";
-CreateAccessTokenRequest request = new CreateAccessTokenRequest();
-
-try {
-    GetAccessTokenResponse response = customersController.createAccessToken(customerId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Access Tokens
-
-Get all access tokens from a customer
-
-```java
-CompletableFuture<ListAccessTokensResponse> getAccessTokens(
-    final String customerId,
-    final Integer page,
-    final Integer size)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `String` | Template, Required | Customer Id |
-| `page` | `Integer` | Query, Optional | Page number |
-| `size` | `Integer` | Query, Optional | Page size |
-
-## Response Type
-
-[`ListAccessTokensResponse`](/doc/models/list-access-tokens-response.md)
-
-## Example Usage
-
-```java
-String customerId = "customer_id8";
-
-try {
-    ListAccessTokensResponse response = customersController.getAccessTokens(customerId, null, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -705,6 +434,82 @@ try {
 ```
 
 
+# Get Address
+
+Get a customer's address
+
+```java
+CompletableFuture<GetAddressResponse> getAddress(
+    final String customerId,
+    final String addressId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `String` | Template, Required | Customer id |
+| `addressId` | `String` | Template, Required | Address Id |
+
+## Response Type
+
+[`GetAddressResponse`](/doc/models/get-address-response.md)
+
+## Example Usage
+
+```java
+String customerId = "customer_id8";
+String addressId = "address_id0";
+
+try {
+    GetAddressResponse response = customersController.getAddress(customerId, addressId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Delete Address
+
+Delete a Customer's address
+
+```java
+CompletableFuture<GetAddressResponse> deleteAddress(
+    final String customerId,
+    final String addressId,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `String` | Template, Required | Customer Id |
+| `addressId` | `String` | Template, Required | Address Id |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetAddressResponse`](/doc/models/get-address-response.md)
+
+## Example Usage
+
+```java
+String customerId = "customer_id8";
+String addressId = "address_id0";
+
+try {
+    GetAddressResponse response = customersController.deleteAddress(customerId, addressId, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
 # Get Access Token
 
 Get a Customer's access token
@@ -775,6 +580,238 @@ request.getMetadata().put("key0", "metadata3");
 
 try {
     GetCustomerResponse response = customersController.updateCustomerMetadata(customerId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Card
+
+Get a customer's card
+
+```java
+CompletableFuture<GetCardResponse> getCard(
+    final String customerId,
+    final String cardId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `String` | Template, Required | Customer id |
+| `cardId` | `String` | Template, Required | Card id |
+
+## Response Type
+
+[`GetCardResponse`](/doc/models/get-card-response.md)
+
+## Example Usage
+
+```java
+String customerId = "customer_id8";
+String cardId = "card_id4";
+
+try {
+    GetCardResponse response = customersController.getCard(customerId, cardId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Delete Access Tokens
+
+Delete a Customer's access tokens
+
+```java
+CompletableFuture<ListAccessTokensResponse> deleteAccessTokens(
+    final String customerId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `String` | Template, Required | Customer Id |
+
+## Response Type
+
+[`ListAccessTokensResponse`](/doc/models/list-access-tokens-response.md)
+
+## Example Usage
+
+```java
+String customerId = "customer_id8";
+
+try {
+    ListAccessTokensResponse response = customersController.deleteAccessTokens(customerId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Create Access Token
+
+Creates a access token for a customer
+
+```java
+CompletableFuture<GetAccessTokenResponse> createAccessToken(
+    final String customerId,
+    final CreateAccessTokenRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `String` | Template, Required | Customer Id |
+| `request` | [`CreateAccessTokenRequest`](/doc/models/create-access-token-request.md) | Body, Required | Request for creating a access token |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetAccessTokenResponse`](/doc/models/get-access-token-response.md)
+
+## Example Usage
+
+```java
+String customerId = "customer_id8";
+CreateAccessTokenRequest request = new CreateAccessTokenRequest();
+
+try {
+    GetAccessTokenResponse response = customersController.createAccessToken(customerId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Access Tokens
+
+Get all access tokens from a customer
+
+```java
+CompletableFuture<ListAccessTokensResponse> getAccessTokens(
+    final String customerId,
+    final Integer page,
+    final Integer size)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `String` | Template, Required | Customer Id |
+| `page` | `Integer` | Query, Optional | Page number |
+| `size` | `Integer` | Query, Optional | Page size |
+
+## Response Type
+
+[`ListAccessTokensResponse`](/doc/models/list-access-tokens-response.md)
+
+## Example Usage
+
+```java
+String customerId = "customer_id8";
+
+try {
+    ListAccessTokensResponse response = customersController.getAccessTokens(customerId, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Customers
+
+Get all Customers
+
+```java
+CompletableFuture<ListCustomersResponse> getCustomers(
+    final String name,
+    final String document,
+    final Integer page,
+    final Integer size,
+    final String email,
+    final String code)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `name` | `String` | Query, Optional | Name of the Customer |
+| `document` | `String` | Query, Optional | Document of the Customer |
+| `page` | `Integer` | Query, Optional | Current page the the search<br>**Default**: `1` |
+| `size` | `Integer` | Query, Optional | Quantity pages of the search<br>**Default**: `10` |
+| `email` | `String` | Query, Optional | Customer's email |
+| `code` | `String` | Query, Optional | Customer's code |
+
+## Response Type
+
+[`ListCustomersResponse`](/doc/models/list-customers-response.md)
+
+## Example Usage
+
+```java
+Integer page = 1;
+Integer size = 10;
+
+try {
+    ListCustomersResponse response = customersController.getCustomers(null, null, page, size, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Customer
+
+Updates a customer
+
+```java
+CompletableFuture<GetCustomerResponse> updateCustomer(
+    final String customerId,
+    final UpdateCustomerRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `String` | Template, Required | Customer id |
+| `request` | [`UpdateCustomerRequest`](/doc/models/update-customer-request.md) | Body, Required | Request for updating a customer |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetCustomerResponse`](/doc/models/get-customer-response.md)
+
+## Example Usage
+
+```java
+String customerId = "customer_id8";
+UpdateCustomerRequest request = new UpdateCustomerRequest();
+
+try {
+    GetCustomerResponse response = customersController.updateCustomer(customerId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -886,43 +923,6 @@ String customerId = "customer_id8";
 
 try {
     GetCustomerResponse response = customersController.getCustomer(customerId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Card
-
-Get a customer's card
-
-```java
-CompletableFuture<GetCardResponse> getCard(
-    final String customerId,
-    final String cardId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `String` | Template, Required | Customer id |
-| `cardId` | `String` | Template, Required | Card id |
-
-## Response Type
-
-[`GetCardResponse`](/doc/models/get-card-response.md)
-
-## Example Usage
-
-```java
-String customerId = "customer_id8";
-String cardId = "card_id4";
-
-try {
-    GetCardResponse response = customersController.getCard(customerId, cardId);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/controllers/invoices.md
+++ b/doc/controllers/invoices.md
@@ -10,122 +10,13 @@ InvoicesController invoicesController = client.getInvoicesController();
 
 ## Methods
 
-* [Update Invoice Metadata](/doc/controllers/invoices.md#update-invoice-metadata)
-* [Get Partial Invoice](/doc/controllers/invoices.md#get-partial-invoice)
-* [Cancel Invoice](/doc/controllers/invoices.md#cancel-invoice)
 * [Create Invoice](/doc/controllers/invoices.md#create-invoice)
 * [Get Invoices](/doc/controllers/invoices.md#get-invoices)
-* [Get Invoice](/doc/controllers/invoices.md#get-invoice)
+* [Cancel Invoice](/doc/controllers/invoices.md#cancel-invoice)
+* [Update Invoice Metadata](/doc/controllers/invoices.md#update-invoice-metadata)
+* [Get Partial Invoice](/doc/controllers/invoices.md#get-partial-invoice)
 * [Update Invoice Status](/doc/controllers/invoices.md#update-invoice-status)
-
-
-# Update Invoice Metadata
-
-Updates the metadata from an invoice
-
-```java
-CompletableFuture<GetInvoiceResponse> updateInvoiceMetadata(
-    final String invoiceId,
-    final UpdateMetadataRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `invoiceId` | `String` | Template, Required | The invoice id |
-| `request` | [`UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the invoice metadata |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```java
-String invoiceId = "invoice_id0";
-UpdateMetadataRequest request = new UpdateMetadataRequest();
-request.setMetadata(new LinkedHashMap<>());
-request.getMetadata().put("key0", "metadata3");
-
-try {
-    GetInvoiceResponse response = invoicesController.updateInvoiceMetadata(invoiceId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Partial Invoice
-
-```java
-CompletableFuture<GetInvoiceResponse> getPartialInvoice(
-    final String subscriptionId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription Id |
-
-## Response Type
-
-[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-
-try {
-    GetInvoiceResponse response = invoicesController.getPartialInvoice(subscriptionId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Cancel Invoice
-
-Cancels an invoice
-
-```java
-CompletableFuture<GetInvoiceResponse> cancelInvoice(
-    final String invoiceId,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `invoiceId` | `String` | Template, Required | Invoice id |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```java
-String invoiceId = "invoice_id0";
-
-try {
-    GetInvoiceResponse response = invoicesController.cancelInvoice(invoiceId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
+* [Get Invoice](/doc/controllers/invoices.md#get-invoice)
 
 
 # Create Invoice
@@ -221,20 +112,22 @@ try {
 ```
 
 
-# Get Invoice
+# Cancel Invoice
 
-Gets an invoice
+Cancels an invoice
 
 ```java
-CompletableFuture<GetInvoiceResponse> getInvoice(
-    final String invoiceId)
+CompletableFuture<GetInvoiceResponse> cancelInvoice(
+    final String invoiceId,
+    final String idempotencyKey)
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `invoiceId` | `String` | Template, Required | Invoice Id |
+| `invoiceId` | `String` | Template, Required | Invoice id |
+| `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
 
@@ -246,7 +139,80 @@ CompletableFuture<GetInvoiceResponse> getInvoice(
 String invoiceId = "invoice_id0";
 
 try {
-    GetInvoiceResponse response = invoicesController.getInvoice(invoiceId);
+    GetInvoiceResponse response = invoicesController.cancelInvoice(invoiceId, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Invoice Metadata
+
+Updates the metadata from an invoice
+
+```java
+CompletableFuture<GetInvoiceResponse> updateInvoiceMetadata(
+    final String invoiceId,
+    final UpdateMetadataRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `invoiceId` | `String` | Template, Required | The invoice id |
+| `request` | [`UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the invoice metadata |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```java
+String invoiceId = "invoice_id0";
+UpdateMetadataRequest request = new UpdateMetadataRequest();
+request.setMetadata(new LinkedHashMap<>());
+request.getMetadata().put("key0", "metadata3");
+
+try {
+    GetInvoiceResponse response = invoicesController.updateInvoiceMetadata(invoiceId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Partial Invoice
+
+```java
+CompletableFuture<GetInvoiceResponse> getPartialInvoice(
+    final String subscriptionId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription Id |
+
+## Response Type
+
+[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+
+try {
+    GetInvoiceResponse response = invoicesController.getPartialInvoice(subscriptionId);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -287,6 +253,40 @@ request.setStatus("status8");
 
 try {
     GetInvoiceResponse response = invoicesController.updateInvoiceStatus(invoiceId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Invoice
+
+Gets an invoice
+
+```java
+CompletableFuture<GetInvoiceResponse> getInvoice(
+    final String invoiceId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `invoiceId` | `String` | Template, Required | Invoice Id |
+
+## Response Type
+
+[`GetInvoiceResponse`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```java
+String invoiceId = "invoice_id0";
+
+try {
+    GetInvoiceResponse response = invoicesController.getInvoice(invoiceId);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/controllers/orders.md
+++ b/doc/controllers/orders.md
@@ -11,15 +11,15 @@ OrdersController ordersController = client.getOrdersController();
 ## Methods
 
 * [Get Orders](/doc/controllers/orders.md#get-orders)
-* [Update Order Item](/doc/controllers/orders.md#update-order-item)
-* [Delete All Order Items](/doc/controllers/orders.md#delete-all-order-items)
-* [Delete Order Item](/doc/controllers/orders.md#delete-order-item)
+* [Get Order Item](/doc/controllers/orders.md#get-order-item)
+* [Get Order](/doc/controllers/orders.md#get-order)
 * [Close Order](/doc/controllers/orders.md#close-order)
 * [Create Order](/doc/controllers/orders.md#create-order)
-* [Create Order Item](/doc/controllers/orders.md#create-order-item)
-* [Get Order Item](/doc/controllers/orders.md#get-order-item)
+* [Update Order Item](/doc/controllers/orders.md#update-order-item)
+* [Delete All Order Items](/doc/controllers/orders.md#delete-all-order-items)
 * [Update Order Metadata](/doc/controllers/orders.md#update-order-metadata)
-* [Get Order](/doc/controllers/orders.md#get-order)
+* [Delete Order Item](/doc/controllers/orders.md#delete-order-item)
+* [Create Order Item](/doc/controllers/orders.md#create-order-item)
 
 
 # Get Orders
@@ -66,14 +66,12 @@ try {
 ```
 
 
-# Update Order Item
+# Get Order Item
 
 ```java
-CompletableFuture<GetOrderItemResponse> updateOrderItem(
+CompletableFuture<GetOrderItemResponse> getOrderItem(
     final String orderId,
-    final String itemId,
-    final UpdateOrderItemRequest request,
-    final String idempotencyKey)
+    final String itemId)
 ```
 
 ## Parameters
@@ -82,8 +80,6 @@ CompletableFuture<GetOrderItemResponse> updateOrderItem(
 |  --- | --- | --- | --- |
 | `orderId` | `String` | Template, Required | Order Id |
 | `itemId` | `String` | Template, Required | Item Id |
-| `request` | [`UpdateOrderItemRequest`](/doc/models/update-order-item-request.md) | Body, Required | Item Model |
-| `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
 
@@ -94,14 +90,9 @@ CompletableFuture<GetOrderItemResponse> updateOrderItem(
 ```java
 String orderId = "orderId2";
 String itemId = "itemId8";
-UpdateOrderItemRequest request = new UpdateOrderItemRequest();
-request.setAmount(242);
-request.setDescription("description6");
-request.setQuantity(100);
-request.setCategory("category4");
 
 try {
-    GetOrderItemResponse response = ordersController.updateOrderItem(orderId, itemId, request, null);
+    GetOrderItemResponse response = ordersController.getOrderItem(orderId, itemId);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -110,20 +101,20 @@ try {
 ```
 
 
-# Delete All Order Items
+# Get Order
+
+Gets an order
 
 ```java
-CompletableFuture<GetOrderResponse> deleteAllOrderItems(
-    final String orderId,
-    final String idempotencyKey)
+CompletableFuture<GetOrderResponse> getOrder(
+    final String orderId)
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `orderId` | `String` | Template, Required | Order Id |
-| `idempotencyKey` | `String` | Header, Optional | - |
+| `orderId` | `String` | Template, Required | Order id |
 
 ## Response Type
 
@@ -132,47 +123,10 @@ CompletableFuture<GetOrderResponse> deleteAllOrderItems(
 ## Example Usage
 
 ```java
-String orderId = "orderId2";
+String orderId = "order_id6";
 
 try {
-    GetOrderResponse response = ordersController.deleteAllOrderItems(orderId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Delete Order Item
-
-```java
-CompletableFuture<GetOrderItemResponse> deleteOrderItem(
-    final String orderId,
-    final String itemId,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `orderId` | `String` | Template, Required | Order Id |
-| `itemId` | `String` | Template, Required | Item Id |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetOrderItemResponse`](/doc/models/get-order-item-response.md)
-
-## Example Usage
-
-```java
-String orderId = "orderId2";
-String itemId = "itemId8";
-
-try {
-    GetOrderItemResponse response = ordersController.deleteOrderItem(orderId, itemId, null);
+    GetOrderResponse response = ordersController.getOrder(orderId);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -320,12 +274,13 @@ try {
 ```
 
 
-# Create Order Item
+# Update Order Item
 
 ```java
-CompletableFuture<GetOrderItemResponse> createOrderItem(
+CompletableFuture<GetOrderItemResponse> updateOrderItem(
     final String orderId,
-    final CreateOrderItemRequest request,
+    final String itemId,
+    final UpdateOrderItemRequest request,
     final String idempotencyKey)
 ```
 
@@ -334,7 +289,8 @@ CompletableFuture<GetOrderItemResponse> createOrderItem(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `orderId` | `String` | Template, Required | Order Id |
-| `request` | [`CreateOrderItemRequest`](/doc/models/create-order-item-request.md) | Body, Required | Order Item Model |
+| `itemId` | `String` | Template, Required | Item Id |
+| `request` | [`UpdateOrderItemRequest`](/doc/models/update-order-item-request.md) | Body, Required | Item Model |
 | `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
@@ -345,14 +301,15 @@ CompletableFuture<GetOrderItemResponse> createOrderItem(
 
 ```java
 String orderId = "orderId2";
-CreateOrderItemRequest request = new CreateOrderItemRequest();
+String itemId = "itemId8";
+UpdateOrderItemRequest request = new UpdateOrderItemRequest();
 request.setAmount(242);
 request.setDescription("description6");
 request.setQuantity(100);
 request.setCategory("category4");
 
 try {
-    GetOrderItemResponse response = ordersController.createOrderItem(orderId, request, null);
+    GetOrderItemResponse response = ordersController.updateOrderItem(orderId, itemId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -361,12 +318,12 @@ try {
 ```
 
 
-# Get Order Item
+# Delete All Order Items
 
 ```java
-CompletableFuture<GetOrderItemResponse> getOrderItem(
+CompletableFuture<GetOrderResponse> deleteAllOrderItems(
     final String orderId,
-    final String itemId)
+    final String idempotencyKey)
 ```
 
 ## Parameters
@@ -374,20 +331,19 @@ CompletableFuture<GetOrderItemResponse> getOrderItem(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `orderId` | `String` | Template, Required | Order Id |
-| `itemId` | `String` | Template, Required | Item Id |
+| `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
 
-[`GetOrderItemResponse`](/doc/models/get-order-item-response.md)
+[`GetOrderResponse`](/doc/models/get-order-response.md)
 
 ## Example Usage
 
 ```java
 String orderId = "orderId2";
-String itemId = "itemId8";
 
 try {
-    GetOrderItemResponse response = ordersController.getOrderItem(orderId, itemId);
+    GetOrderResponse response = ordersController.deleteAllOrderItems(orderId, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -437,32 +393,76 @@ try {
 ```
 
 
-# Get Order
-
-Gets an order
+# Delete Order Item
 
 ```java
-CompletableFuture<GetOrderResponse> getOrder(
-    final String orderId)
+CompletableFuture<GetOrderItemResponse> deleteOrderItem(
+    final String orderId,
+    final String itemId,
+    final String idempotencyKey)
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `orderId` | `String` | Template, Required | Order id |
+| `orderId` | `String` | Template, Required | Order Id |
+| `itemId` | `String` | Template, Required | Item Id |
+| `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
 
-[`GetOrderResponse`](/doc/models/get-order-response.md)
+[`GetOrderItemResponse`](/doc/models/get-order-item-response.md)
 
 ## Example Usage
 
 ```java
-String orderId = "order_id6";
+String orderId = "orderId2";
+String itemId = "itemId8";
 
 try {
-    GetOrderResponse response = ordersController.getOrder(orderId);
+    GetOrderItemResponse response = ordersController.deleteOrderItem(orderId, itemId, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Create Order Item
+
+```java
+CompletableFuture<GetOrderItemResponse> createOrderItem(
+    final String orderId,
+    final CreateOrderItemRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `orderId` | `String` | Template, Required | Order Id |
+| `request` | [`CreateOrderItemRequest`](/doc/models/create-order-item-request.md) | Body, Required | Order Item Model |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetOrderItemResponse`](/doc/models/get-order-item-response.md)
+
+## Example Usage
+
+```java
+String orderId = "orderId2";
+CreateOrderItemRequest request = new CreateOrderItemRequest();
+request.setAmount(242);
+request.setDescription("description6");
+request.setQuantity(100);
+request.setCategory("category4");
+
+try {
+    GetOrderItemResponse response = ordersController.createOrderItem(orderId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/controllers/plans.md
+++ b/doc/controllers/plans.md
@@ -11,15 +11,15 @@ PlansController plansController = client.getPlansController();
 ## Methods
 
 * [Get Plan](/doc/controllers/plans.md#get-plan)
-* [Delete Plan](/doc/controllers/plans.md#delete-plan)
+* [Update Plan](/doc/controllers/plans.md#update-plan)
 * [Update Plan Metadata](/doc/controllers/plans.md#update-plan-metadata)
-* [Update Plan Item](/doc/controllers/plans.md#update-plan-item)
-* [Create Plan Item](/doc/controllers/plans.md#create-plan-item)
-* [Get Plan Item](/doc/controllers/plans.md#get-plan-item)
-* [Create Plan](/doc/controllers/plans.md#create-plan)
 * [Delete Plan Item](/doc/controllers/plans.md#delete-plan-item)
 * [Get Plans](/doc/controllers/plans.md#get-plans)
-* [Update Plan](/doc/controllers/plans.md#update-plan)
+* [Get Plan Item](/doc/controllers/plans.md#get-plan-item)
+* [Delete Plan](/doc/controllers/plans.md#delete-plan)
+* [Update Plan Item](/doc/controllers/plans.md#update-plan-item)
+* [Create Plan Item](/doc/controllers/plans.md#create-plan-item)
+* [Create Plan](/doc/controllers/plans.md#create-plan)
 
 
 # Get Plan
@@ -56,13 +56,14 @@ try {
 ```
 
 
-# Delete Plan
+# Update Plan
 
-Deletes a plan
+Updates a plan
 
 ```java
-CompletableFuture<GetPlanResponse> deletePlan(
+CompletableFuture<GetPlanResponse> updatePlan(
     final String planId,
+    final UpdatePlanRequest request,
     final String idempotencyKey)
 ```
 
@@ -71,6 +72,7 @@ CompletableFuture<GetPlanResponse> deletePlan(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `planId` | `String` | Template, Required | Plan id |
+| `request` | [`UpdatePlanRequest`](/doc/models/update-plan-request.md) | Body, Required | Request for updating a plan |
 | `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
@@ -81,9 +83,30 @@ CompletableFuture<GetPlanResponse> deletePlan(
 
 ```java
 String planId = "plan_id8";
+UpdatePlanRequest request = new UpdatePlanRequest();
+request.setName("name6");
+request.setDescription("description6");
+request.setInstallments(new LinkedList<>());
+request.getInstallments().add(151);
+request.getInstallments().add(152);
+request.setStatementDescriptor("statement_descriptor6");
+request.setCurrency("currency6");
+request.setInterval("interval4");
+request.setIntervalCount(114);
+request.setPaymentMethods(new LinkedList<>());
+request.getPaymentMethods().add("payment_methods1");
+request.getPaymentMethods().add("payment_methods0");
+request.getPaymentMethods().add("payment_methods9");
+request.setBillingType("billing_type0");
+request.setStatus("status8");
+request.setShippable(false);
+request.setBillingDays(new LinkedList<>());
+request.getBillingDays().add(115);
+request.setMetadata(new LinkedHashMap<>());
+request.getMetadata().put("key0", "metadata3");
 
 try {
-    GetPlanResponse response = plansController.deletePlan(planId, null);
+    GetPlanResponse response = plansController.updatePlan(planId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -125,6 +148,162 @@ request.getMetadata().put("key0", "metadata3");
 
 try {
     GetPlanResponse response = plansController.updatePlanMetadata(planId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Delete Plan Item
+
+Removes an item from a plan
+
+```java
+CompletableFuture<GetPlanItemResponse> deletePlanItem(
+    final String planId,
+    final String planItemId,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `String` | Template, Required | Plan id |
+| `planItemId` | `String` | Template, Required | Plan item id |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetPlanItemResponse`](/doc/models/get-plan-item-response.md)
+
+## Example Usage
+
+```java
+String planId = "plan_id8";
+String planItemId = "plan_item_id0";
+
+try {
+    GetPlanItemResponse response = plansController.deletePlanItem(planId, planItemId, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Plans
+
+Gets all plans
+
+```java
+CompletableFuture<ListPlansResponse> getPlans(
+    final Integer page,
+    final Integer size,
+    final String name,
+    final String status,
+    final String billingType,
+    final LocalDateTime createdSince,
+    final LocalDateTime createdUntil)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `page` | `Integer` | Query, Optional | Page number |
+| `size` | `Integer` | Query, Optional | Page size |
+| `name` | `String` | Query, Optional | Filter for Plan's name |
+| `status` | `String` | Query, Optional | Filter for Plan's status |
+| `billingType` | `String` | Query, Optional | Filter for plan's billing type |
+| `createdSince` | `LocalDateTime` | Query, Optional | Filter for plan's creation date start range |
+| `createdUntil` | `LocalDateTime` | Query, Optional | Filter for plan's creation date end range |
+
+## Response Type
+
+[`ListPlansResponse`](/doc/models/list-plans-response.md)
+
+## Example Usage
+
+```java
+try {
+    ListPlansResponse response = plansController.getPlans(null, null, null, null, null, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Plan Item
+
+Gets a plan item
+
+```java
+CompletableFuture<GetPlanItemResponse> getPlanItem(
+    final String planId,
+    final String planItemId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `String` | Template, Required | Plan id |
+| `planItemId` | `String` | Template, Required | Plan item id |
+
+## Response Type
+
+[`GetPlanItemResponse`](/doc/models/get-plan-item-response.md)
+
+## Example Usage
+
+```java
+String planId = "plan_id8";
+String planItemId = "plan_item_id0";
+
+try {
+    GetPlanItemResponse response = plansController.getPlanItem(planId, planItemId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Delete Plan
+
+Deletes a plan
+
+```java
+CompletableFuture<GetPlanResponse> deletePlan(
+    final String planId,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `String` | Template, Required | Plan id |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetPlanResponse`](/doc/models/get-plan-response.md)
+
+## Example Usage
+
+```java
+String planId = "plan_id8";
+
+try {
+    GetPlanResponse response = plansController.deletePlan(planId, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -235,43 +414,6 @@ request.setDescription("description6");
 
 try {
     GetPlanItemResponse response = plansController.createPlanItem(planId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Plan Item
-
-Gets a plan item
-
-```java
-CompletableFuture<GetPlanItemResponse> getPlanItem(
-    final String planId,
-    final String planItemId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `String` | Template, Required | Plan id |
-| `planItemId` | `String` | Template, Required | Plan item id |
-
-## Response Type
-
-[`GetPlanItemResponse`](/doc/models/get-plan-item-response.md)
-
-## Example Usage
-
-```java
-String planId = "plan_id8";
-String planItemId = "plan_item_id0";
-
-try {
-    GetPlanItemResponse response = plansController.getPlanItem(planId, planItemId);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -402,148 +544,6 @@ body.getMetadata().put("key1", "metadata8");
 
 try {
     GetPlanResponse response = plansController.createPlan(body, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Delete Plan Item
-
-Removes an item from a plan
-
-```java
-CompletableFuture<GetPlanItemResponse> deletePlanItem(
-    final String planId,
-    final String planItemId,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `String` | Template, Required | Plan id |
-| `planItemId` | `String` | Template, Required | Plan item id |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetPlanItemResponse`](/doc/models/get-plan-item-response.md)
-
-## Example Usage
-
-```java
-String planId = "plan_id8";
-String planItemId = "plan_item_id0";
-
-try {
-    GetPlanItemResponse response = plansController.deletePlanItem(planId, planItemId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Plans
-
-Gets all plans
-
-```java
-CompletableFuture<ListPlansResponse> getPlans(
-    final Integer page,
-    final Integer size,
-    final String name,
-    final String status,
-    final String billingType,
-    final LocalDateTime createdSince,
-    final LocalDateTime createdUntil)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `page` | `Integer` | Query, Optional | Page number |
-| `size` | `Integer` | Query, Optional | Page size |
-| `name` | `String` | Query, Optional | Filter for Plan's name |
-| `status` | `String` | Query, Optional | Filter for Plan's status |
-| `billingType` | `String` | Query, Optional | Filter for plan's billing type |
-| `createdSince` | `LocalDateTime` | Query, Optional | Filter for plan's creation date start range |
-| `createdUntil` | `LocalDateTime` | Query, Optional | Filter for plan's creation date end range |
-
-## Response Type
-
-[`ListPlansResponse`](/doc/models/list-plans-response.md)
-
-## Example Usage
-
-```java
-try {
-    ListPlansResponse response = plansController.getPlans(null, null, null, null, null, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Plan
-
-Updates a plan
-
-```java
-CompletableFuture<GetPlanResponse> updatePlan(
-    final String planId,
-    final UpdatePlanRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `String` | Template, Required | Plan id |
-| `request` | [`UpdatePlanRequest`](/doc/models/update-plan-request.md) | Body, Required | Request for updating a plan |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetPlanResponse`](/doc/models/get-plan-response.md)
-
-## Example Usage
-
-```java
-String planId = "plan_id8";
-UpdatePlanRequest request = new UpdatePlanRequest();
-request.setName("name6");
-request.setDescription("description6");
-request.setInstallments(new LinkedList<>());
-request.getInstallments().add(151);
-request.getInstallments().add(152);
-request.setStatementDescriptor("statement_descriptor6");
-request.setCurrency("currency6");
-request.setInterval("interval4");
-request.setIntervalCount(114);
-request.setPaymentMethods(new LinkedList<>());
-request.getPaymentMethods().add("payment_methods1");
-request.getPaymentMethods().add("payment_methods0");
-request.getPaymentMethods().add("payment_methods9");
-request.setBillingType("billing_type0");
-request.setStatus("status8");
-request.setShippable(false);
-request.setBillingDays(new LinkedList<>());
-request.getBillingDays().add(115);
-request.setMetadata(new LinkedHashMap<>());
-request.getMetadata().put("key0", "metadata3");
-
-try {
-    GetPlanResponse response = plansController.updatePlan(planId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/controllers/recipients.md
+++ b/doc/controllers/recipients.md
@@ -14,21 +14,21 @@ RecipientsController recipientsController = client.getRecipientsController();
 * [Create Anticipation](/doc/controllers/recipients.md#create-anticipation)
 * [Get Anticipation Limits](/doc/controllers/recipients.md#get-anticipation-limits)
 * [Get Recipients](/doc/controllers/recipients.md#get-recipients)
-* [Get Withdraw by Id](/doc/controllers/recipients.md#get-withdraw-by-id)
-* [Update Recipient Default Bank Account](/doc/controllers/recipients.md#update-recipient-default-bank-account)
 * [Update Recipient Metadata](/doc/controllers/recipients.md#update-recipient-metadata)
-* [Get Transfers](/doc/controllers/recipients.md#get-transfers)
 * [Get Transfer](/doc/controllers/recipients.md#get-transfer)
-* [Create Withdraw](/doc/controllers/recipients.md#create-withdraw)
-* [Update Automatic Anticipation Settings](/doc/controllers/recipients.md#update-automatic-anticipation-settings)
 * [Get Anticipation](/doc/controllers/recipients.md#get-anticipation)
 * [Update Recipient Transfer Settings](/doc/controllers/recipients.md#update-recipient-transfer-settings)
 * [Get Anticipations](/doc/controllers/recipients.md#get-anticipations)
-* [Get Recipient](/doc/controllers/recipients.md#get-recipient)
+* [Update Recipient Default Bank Account](/doc/controllers/recipients.md#update-recipient-default-bank-account)
+* [Create Withdraw](/doc/controllers/recipients.md#create-withdraw)
 * [Get Balance](/doc/controllers/recipients.md#get-balance)
-* [Get Withdrawals](/doc/controllers/recipients.md#get-withdrawals)
 * [Create Transfer](/doc/controllers/recipients.md#create-transfer)
 * [Create Recipient](/doc/controllers/recipients.md#create-recipient)
+* [Update Automatic Anticipation Settings](/doc/controllers/recipients.md#update-automatic-anticipation-settings)
+* [Get Recipient](/doc/controllers/recipients.md#get-recipient)
+* [Get Withdrawals](/doc/controllers/recipients.md#get-withdrawals)
+* [Get Withdraw by Id](/doc/controllers/recipients.md#get-withdraw-by-id)
+* [Get Transfers](/doc/controllers/recipients.md#get-transfers)
 * [Get Recipient by Code](/doc/controllers/recipients.md#get-recipient-by-code)
 * [Get Default Recipient](/doc/controllers/recipients.md#get-default-recipient)
 
@@ -195,95 +195,6 @@ try {
 ```
 
 
-# Get Withdraw by Id
-
-```java
-CompletableFuture<GetWithdrawResponse> getWithdrawById(
-    final String recipientId,
-    final String withdrawalId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `String` | Template, Required | - |
-| `withdrawalId` | `String` | Template, Required | - |
-
-## Response Type
-
-[`GetWithdrawResponse`](/doc/models/get-withdraw-response.md)
-
-## Example Usage
-
-```java
-String recipientId = "recipient_id0";
-String withdrawalId = "withdrawal_id2";
-
-try {
-    GetWithdrawResponse response = recipientsController.getWithdrawById(recipientId, withdrawalId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Recipient Default Bank Account
-
-Updates the default bank account from a recipient
-
-```java
-CompletableFuture<GetRecipientResponse> updateRecipientDefaultBankAccount(
-    final String recipientId,
-    final UpdateRecipientBankAccountRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `String` | Template, Required | Recipient id |
-| `request` | [`UpdateRecipientBankAccountRequest`](/doc/models/update-recipient-bank-account-request.md) | Body, Required | Bank account data |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetRecipientResponse`](/doc/models/get-recipient-response.md)
-
-## Example Usage
-
-```java
-String recipientId = "recipient_id0";
-UpdateRecipientBankAccountRequest request = new UpdateRecipientBankAccountRequest();
-request.setBankAccount(new CreateBankAccountRequest());
-request.getBankAccount().setHolderName("holder_name6");
-request.getBankAccount().setHolderType("holder_type2");
-request.getBankAccount().setHolderDocument("holder_document4");
-request.getBankAccount().setBank("bank8");
-request.getBankAccount().setBranchNumber("branch_number6");
-request.getBankAccount().setBranchCheckDigit("branch_check_digit6");
-request.getBankAccount().setAccountNumber("account_number0");
-request.getBankAccount().setAccountCheckDigit("account_check_digit6");
-request.getBankAccount().setType("type0");
-request.getBankAccount().setMetadata(new LinkedHashMap<>());
-request.getBankAccount().getMetadata().put("key0", "metadata9");
-request.getBankAccount().getMetadata().put("key1", "metadata8");
-request.getBankAccount().setPixKey("pix_key4");
-request.setPaymentMode("bank_transfer");
-
-try {
-    GetRecipientResponse response = recipientsController.updateRecipientDefaultBankAccount(recipientId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
 # Update Recipient Metadata
 
 Updates recipient metadata
@@ -325,50 +236,6 @@ try {
 ```
 
 
-# Get Transfers
-
-Gets a paginated list of transfers for the recipient
-
-```java
-CompletableFuture<ListTransferResponse> getTransfers(
-    final String recipientId,
-    final Integer page,
-    final Integer size,
-    final String status,
-    final LocalDateTime createdSince,
-    final LocalDateTime createdUntil)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `String` | Template, Required | Recipient id |
-| `page` | `Integer` | Query, Optional | Page number |
-| `size` | `Integer` | Query, Optional | Page size |
-| `status` | `String` | Query, Optional | Filter for transfer status |
-| `createdSince` | `LocalDateTime` | Query, Optional | Filter for start range of transfer creation date |
-| `createdUntil` | `LocalDateTime` | Query, Optional | Filter for end range of transfer creation date |
-
-## Response Type
-
-[`ListTransferResponse`](/doc/models/list-transfer-response.md)
-
-## Example Usage
-
-```java
-String recipientId = "recipient_id0";
-
-try {
-    ListTransferResponse response = recipientsController.getTransfers(recipientId, null, null, null, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
 # Get Transfer
 
 Gets a transfer
@@ -398,81 +265,6 @@ String transferId = "transfer_id6";
 
 try {
     GetTransferResponse response = recipientsController.getTransfer(recipientId, transferId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Create Withdraw
-
-```java
-CompletableFuture<GetWithdrawResponse> createWithdraw(
-    final String recipientId,
-    final CreateWithdrawRequest request)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `String` | Template, Required | - |
-| `request` | [`CreateWithdrawRequest`](/doc/models/create-withdraw-request.md) | Body, Required | - |
-
-## Response Type
-
-[`GetWithdrawResponse`](/doc/models/get-withdraw-response.md)
-
-## Example Usage
-
-```java
-String recipientId = "recipient_id0";
-CreateWithdrawRequest request = new CreateWithdrawRequest();
-request.setAmount(242);
-
-try {
-    GetWithdrawResponse response = recipientsController.createWithdraw(recipientId, request);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Automatic Anticipation Settings
-
-Updates recipient metadata
-
-```java
-CompletableFuture<GetRecipientResponse> updateAutomaticAnticipationSettings(
-    final String recipientId,
-    final UpdateAutomaticAnticipationSettingsRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `String` | Template, Required | Recipient id |
-| `request` | [`UpdateAutomaticAnticipationSettingsRequest`](/doc/models/update-automatic-anticipation-settings-request.md) | Body, Required | Metadata |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetRecipientResponse`](/doc/models/get-recipient-response.md)
-
-## Example Usage
-
-```java
-String recipientId = "recipient_id0";
-UpdateAutomaticAnticipationSettingsRequest request = new UpdateAutomaticAnticipationSettingsRequest();
-
-try {
-    GetRecipientResponse response = recipientsController.updateAutomaticAnticipationSettings(recipientId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -608,20 +400,24 @@ try {
 ```
 
 
-# Get Recipient
+# Update Recipient Default Bank Account
 
-Retrieves recipient information
+Updates the default bank account from a recipient
 
 ```java
-CompletableFuture<GetRecipientResponse> getRecipient(
-    final String recipientId)
+CompletableFuture<GetRecipientResponse> updateRecipientDefaultBankAccount(
+    final String recipientId,
+    final UpdateRecipientBankAccountRequest request,
+    final String idempotencyKey)
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `recipientId` | `String` | Template, Required | Recipiend id |
+| `recipientId` | `String` | Template, Required | Recipient id |
+| `request` | [`UpdateRecipientBankAccountRequest`](/doc/models/update-recipient-bank-account-request.md) | Body, Required | Bank account data |
+| `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
 
@@ -631,9 +427,61 @@ CompletableFuture<GetRecipientResponse> getRecipient(
 
 ```java
 String recipientId = "recipient_id0";
+UpdateRecipientBankAccountRequest request = new UpdateRecipientBankAccountRequest();
+request.setBankAccount(new CreateBankAccountRequest());
+request.getBankAccount().setHolderName("holder_name6");
+request.getBankAccount().setHolderType("holder_type2");
+request.getBankAccount().setHolderDocument("holder_document4");
+request.getBankAccount().setBank("bank8");
+request.getBankAccount().setBranchNumber("branch_number6");
+request.getBankAccount().setBranchCheckDigit("branch_check_digit6");
+request.getBankAccount().setAccountNumber("account_number0");
+request.getBankAccount().setAccountCheckDigit("account_check_digit6");
+request.getBankAccount().setType("type0");
+request.getBankAccount().setMetadata(new LinkedHashMap<>());
+request.getBankAccount().getMetadata().put("key0", "metadata9");
+request.getBankAccount().getMetadata().put("key1", "metadata8");
+request.getBankAccount().setPixKey("pix_key4");
+request.setPaymentMode("bank_transfer");
 
 try {
-    GetRecipientResponse response = recipientsController.getRecipient(recipientId);
+    GetRecipientResponse response = recipientsController.updateRecipientDefaultBankAccount(recipientId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Create Withdraw
+
+```java
+CompletableFuture<GetWithdrawResponse> createWithdraw(
+    final String recipientId,
+    final CreateWithdrawRequest request)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `String` | Template, Required | - |
+| `request` | [`CreateWithdrawRequest`](/doc/models/create-withdraw-request.md) | Body, Required | - |
+
+## Response Type
+
+[`GetWithdrawResponse`](/doc/models/get-withdraw-response.md)
+
+## Example Usage
+
+```java
+String recipientId = "recipient_id0";
+CreateWithdrawRequest request = new CreateWithdrawRequest();
+request.setAmount(242);
+
+try {
+    GetWithdrawResponse response = recipientsController.createWithdraw(recipientId, request);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -668,50 +516,6 @@ String recipientId = "recipient_id0";
 
 try {
     GetBalanceResponse response = recipientsController.getBalance(recipientId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Withdrawals
-
-Gets a paginated list of transfers for the recipient
-
-```java
-CompletableFuture<ListWithdrawals> getWithdrawals(
-    final String recipientId,
-    final Integer page,
-    final Integer size,
-    final String status,
-    final LocalDateTime createdSince,
-    final LocalDateTime createdUntil)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `String` | Template, Required | - |
-| `page` | `Integer` | Query, Optional | - |
-| `size` | `Integer` | Query, Optional | - |
-| `status` | `String` | Query, Optional | - |
-| `createdSince` | `LocalDateTime` | Query, Optional | - |
-| `createdUntil` | `LocalDateTime` | Query, Optional | - |
-
-## Response Type
-
-[`ListWithdrawals`](/doc/models/list-withdrawals.md)
-
-## Example Usage
-
-```java
-String recipientId = "recipient_id0";
-
-try {
-    ListWithdrawals response = recipientsController.getWithdrawals(recipientId, null, null, null, null, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -812,6 +616,202 @@ request.setPaymentMode("bank_transfer");
 
 try {
     GetRecipientResponse response = recipientsController.createRecipient(request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Automatic Anticipation Settings
+
+Updates recipient metadata
+
+```java
+CompletableFuture<GetRecipientResponse> updateAutomaticAnticipationSettings(
+    final String recipientId,
+    final UpdateAutomaticAnticipationSettingsRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `String` | Template, Required | Recipient id |
+| `request` | [`UpdateAutomaticAnticipationSettingsRequest`](/doc/models/update-automatic-anticipation-settings-request.md) | Body, Required | Metadata |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetRecipientResponse`](/doc/models/get-recipient-response.md)
+
+## Example Usage
+
+```java
+String recipientId = "recipient_id0";
+UpdateAutomaticAnticipationSettingsRequest request = new UpdateAutomaticAnticipationSettingsRequest();
+
+try {
+    GetRecipientResponse response = recipientsController.updateAutomaticAnticipationSettings(recipientId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Recipient
+
+Retrieves recipient information
+
+```java
+CompletableFuture<GetRecipientResponse> getRecipient(
+    final String recipientId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `String` | Template, Required | Recipiend id |
+
+## Response Type
+
+[`GetRecipientResponse`](/doc/models/get-recipient-response.md)
+
+## Example Usage
+
+```java
+String recipientId = "recipient_id0";
+
+try {
+    GetRecipientResponse response = recipientsController.getRecipient(recipientId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Withdrawals
+
+Gets a paginated list of transfers for the recipient
+
+```java
+CompletableFuture<ListWithdrawals> getWithdrawals(
+    final String recipientId,
+    final Integer page,
+    final Integer size,
+    final String status,
+    final LocalDateTime createdSince,
+    final LocalDateTime createdUntil)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `String` | Template, Required | - |
+| `page` | `Integer` | Query, Optional | - |
+| `size` | `Integer` | Query, Optional | - |
+| `status` | `String` | Query, Optional | - |
+| `createdSince` | `LocalDateTime` | Query, Optional | - |
+| `createdUntil` | `LocalDateTime` | Query, Optional | - |
+
+## Response Type
+
+[`ListWithdrawals`](/doc/models/list-withdrawals.md)
+
+## Example Usage
+
+```java
+String recipientId = "recipient_id0";
+
+try {
+    ListWithdrawals response = recipientsController.getWithdrawals(recipientId, null, null, null, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Withdraw by Id
+
+```java
+CompletableFuture<GetWithdrawResponse> getWithdrawById(
+    final String recipientId,
+    final String withdrawalId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `String` | Template, Required | - |
+| `withdrawalId` | `String` | Template, Required | - |
+
+## Response Type
+
+[`GetWithdrawResponse`](/doc/models/get-withdraw-response.md)
+
+## Example Usage
+
+```java
+String recipientId = "recipient_id0";
+String withdrawalId = "withdrawal_id2";
+
+try {
+    GetWithdrawResponse response = recipientsController.getWithdrawById(recipientId, withdrawalId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Transfers
+
+Gets a paginated list of transfers for the recipient
+
+```java
+CompletableFuture<ListTransferResponse> getTransfers(
+    final String recipientId,
+    final Integer page,
+    final Integer size,
+    final String status,
+    final LocalDateTime createdSince,
+    final LocalDateTime createdUntil)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `String` | Template, Required | Recipient id |
+| `page` | `Integer` | Query, Optional | Page number |
+| `size` | `Integer` | Query, Optional | Page size |
+| `status` | `String` | Query, Optional | Filter for transfer status |
+| `createdSince` | `LocalDateTime` | Query, Optional | Filter for start range of transfer creation date |
+| `createdUntil` | `LocalDateTime` | Query, Optional | Filter for end range of transfer creation date |
+
+## Response Type
+
+[`ListTransferResponse`](/doc/models/list-transfer-response.md)
+
+## Example Usage
+
+```java
+String recipientId = "recipient_id0";
+
+try {
+    ListTransferResponse response = recipientsController.getTransfers(recipientId, null, null, null, null, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/controllers/subscriptions.md
+++ b/doc/controllers/subscriptions.md
@@ -11,39 +11,39 @@ SubscriptionsController subscriptionsController = client.getSubscriptionsControl
 ## Methods
 
 * [Renew Subscription](/doc/controllers/subscriptions.md#renew-subscription)
-* [Update Subscription Card](/doc/controllers/subscriptions.md#update-subscription-card)
-* [Delete Usage](/doc/controllers/subscriptions.md#delete-usage)
-* [Create Discount](/doc/controllers/subscriptions.md#create-discount)
-* [Create an Usage](/doc/controllers/subscriptions.md#create-an-usage)
-* [Update Current Cycle Status](/doc/controllers/subscriptions.md#update-current-cycle-status)
 * [Delete Discount](/doc/controllers/subscriptions.md#delete-discount)
-* [Get Subscription Items](/doc/controllers/subscriptions.md#get-subscription-items)
-* [Update Subscription Payment Method](/doc/controllers/subscriptions.md#update-subscription-payment-method)
-* [Get Subscription Item](/doc/controllers/subscriptions.md#get-subscription-item)
 * [Get Subscriptions](/doc/controllers/subscriptions.md#get-subscriptions)
-* [Cancel Subscription](/doc/controllers/subscriptions.md#cancel-subscription)
-* [Create Increment](/doc/controllers/subscriptions.md#create-increment)
-* [Create Usage](/doc/controllers/subscriptions.md#create-usage)
 * [Get Discount by Id](/doc/controllers/subscriptions.md#get-discount-by-id)
 * [Create Subscription](/doc/controllers/subscriptions.md#create-subscription)
 * [Get Increment by Id](/doc/controllers/subscriptions.md#get-increment-by-id)
-* [Update Subscription Affiliation Id](/doc/controllers/subscriptions.md#update-subscription-affiliation-id)
 * [Update Subscription Metadata](/doc/controllers/subscriptions.md#update-subscription-metadata)
 * [Delete Increment](/doc/controllers/subscriptions.md#delete-increment)
-* [Get Subscription Cycles](/doc/controllers/subscriptions.md#get-subscription-cycles)
+* [Get Subscription](/doc/controllers/subscriptions.md#get-subscription)
+* [Update Latest Period End At](/doc/controllers/subscriptions.md#update-latest-period-end-at)
+* [Update Current Cycle Status](/doc/controllers/subscriptions.md#update-current-cycle-status)
+* [Get Subscription Items](/doc/controllers/subscriptions.md#get-subscription-items)
+* [Get Subscription Item](/doc/controllers/subscriptions.md#get-subscription-item)
+* [Update Subscription Affiliation Id](/doc/controllers/subscriptions.md#update-subscription-affiliation-id)
 * [Get Discounts](/doc/controllers/subscriptions.md#get-discounts)
-* [Update Subscription Billing Date](/doc/controllers/subscriptions.md#update-subscription-billing-date)
+* [Update Subscription Item](/doc/controllers/subscriptions.md#update-subscription-item)
+* [Create Subscription Item](/doc/controllers/subscriptions.md#create-subscription-item)
+* [Get Usages](/doc/controllers/subscriptions.md#get-usages)
+* [Update Subscription Minium Price](/doc/controllers/subscriptions.md#update-subscription-minium-price)
+* [Get Subscription Cycle by Id](/doc/controllers/subscriptions.md#get-subscription-cycle-by-id)
+* [Create an Usage](/doc/controllers/subscriptions.md#create-an-usage)
+* [Cancel Subscription](/doc/controllers/subscriptions.md#cancel-subscription)
 * [Delete Subscription Item](/doc/controllers/subscriptions.md#delete-subscription-item)
 * [Get Increments](/doc/controllers/subscriptions.md#get-increments)
 * [Update Subscription Due Days](/doc/controllers/subscriptions.md#update-subscription-due-days)
+* [Update Subscription Card](/doc/controllers/subscriptions.md#update-subscription-card)
+* [Delete Usage](/doc/controllers/subscriptions.md#delete-usage)
+* [Create Discount](/doc/controllers/subscriptions.md#create-discount)
+* [Update Subscription Payment Method](/doc/controllers/subscriptions.md#update-subscription-payment-method)
+* [Create Increment](/doc/controllers/subscriptions.md#create-increment)
+* [Create Usage](/doc/controllers/subscriptions.md#create-usage)
+* [Get Subscription Cycles](/doc/controllers/subscriptions.md#get-subscription-cycles)
+* [Update Subscription Billing Date](/doc/controllers/subscriptions.md#update-subscription-billing-date)
 * [Update Subscription Start At](/doc/controllers/subscriptions.md#update-subscription-start-at)
-* [Update Subscription Item](/doc/controllers/subscriptions.md#update-subscription-item)
-* [Create Subscription Item](/doc/controllers/subscriptions.md#create-subscription-item)
-* [Get Subscription](/doc/controllers/subscriptions.md#get-subscription)
-* [Get Usages](/doc/controllers/subscriptions.md#get-usages)
-* [Update Latest Period End At](/doc/controllers/subscriptions.md#update-latest-period-end-at)
-* [Update Subscription Minium Price](/doc/controllers/subscriptions.md#update-subscription-minium-price)
-* [Get Subscription Cycle by Id](/doc/controllers/subscriptions.md#get-subscription-cycle-by-id)
 * [Get Usage Report](/doc/controllers/subscriptions.md#get-usage-report)
 
 
@@ -73,237 +73,6 @@ String subscriptionId = "subscription_id0";
 
 try {
     GetPeriodResponse response = subscriptionsController.renewSubscription(subscriptionId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Subscription Card
-
-Updates the credit card from a subscription
-
-```java
-CompletableFuture<GetSubscriptionResponse> updateSubscriptionCard(
-    final String subscriptionId,
-    final UpdateSubscriptionCardRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription id |
-| `request` | [`UpdateSubscriptionCardRequest`](/doc/models/update-subscription-card-request.md) | Body, Required | Request for updating a card |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-UpdateSubscriptionCardRequest request = new UpdateSubscriptionCardRequest();
-request.setCard(new CreateCardRequest());
-request.getCard().setNumber("number2");
-request.getCard().setHolderName("holder_name6");
-request.getCard().setExpMonth(80);
-request.getCard().setExpYear(216);
-request.getCard().setCvv("cvv8");
-request.getCard().setBillingAddress(new CreateAddressRequest());
-request.getCard().getBillingAddress().setStreet("street2");
-request.getCard().getBillingAddress().setNumber("number0");
-request.getCard().getBillingAddress().setZipCode("zip_code6");
-request.getCard().getBillingAddress().setNeighborhood("neighborhood8");
-request.getCard().getBillingAddress().setCity("city8");
-request.getCard().getBillingAddress().setState("state2");
-request.getCard().getBillingAddress().setCountry("country6");
-request.getCard().getBillingAddress().setComplement("complement2");
-request.getCard().getBillingAddress().setMetadata(new LinkedHashMap<>());
-request.getCard().getBillingAddress().getMetadata().put("key0", "metadata1");
-request.getCard().getBillingAddress().setLine1("line_14");
-request.getCard().getBillingAddress().setLine2("line_20");
-request.getCard().setBrand("brand4");
-request.getCard().setBillingAddressId("billing_address_id6");
-request.getCard().setMetadata(new LinkedHashMap<>());
-request.getCard().getMetadata().put("key0", "metadata3");
-request.getCard().getMetadata().put("key1", "metadata4");
-request.getCard().getMetadata().put("key2", "metadata5");
-request.getCard().setType("credit");
-request.getCard().setOptions(new CreateCardOptionsRequest());
-request.getCard().getOptions().setVerifyCard(false);
-request.getCard().setPrivateLabel(false);
-request.getCard().setLabel("label0");
-request.setCardId("card_id2");
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionCard(subscriptionId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Delete Usage
-
-Deletes a usage
-
-```java
-CompletableFuture<GetUsageResponse> deleteUsage(
-    final String subscriptionId,
-    final String itemId,
-    final String usageId,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | The subscription id |
-| `itemId` | `String` | Template, Required | The subscription item id |
-| `usageId` | `String` | Template, Required | The usage id |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetUsageResponse`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-String itemId = "item_id0";
-String usageId = "usage_id0";
-
-try {
-    GetUsageResponse response = subscriptionsController.deleteUsage(subscriptionId, itemId, usageId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Create Discount
-
-Creates a discount
-
-```java
-CompletableFuture<GetDiscountResponse> createDiscount(
-    final String subscriptionId,
-    final CreateDiscountRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription id |
-| `request` | [`CreateDiscountRequest`](/doc/models/create-discount-request.md) | Body, Required | Request for creating a discount |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetDiscountResponse`](/doc/models/get-discount-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-CreateDiscountRequest request = new CreateDiscountRequest();
-request.setValue(185.28);
-request.setDiscountType("discount_type4");
-request.setItemId("item_id6");
-
-try {
-    GetDiscountResponse response = subscriptionsController.createDiscount(subscriptionId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Create an Usage
-
-Create Usage
-
-```java
-CompletableFuture<GetUsageResponse> createAnUsage(
-    final String subscriptionId,
-    final String itemId,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription id |
-| `itemId` | `String` | Template, Required | Item id |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetUsageResponse`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-String itemId = "item_id0";
-
-try {
-    GetUsageResponse response = subscriptionsController.createAnUsage(subscriptionId, itemId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Current Cycle Status
-
-```java
-CompletableFuture<Void> updateCurrentCycleStatus(
-    final String subscriptionId,
-    final UpdateCurrentCycleStatusRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription Id |
-| `request` | [`UpdateCurrentCycleStatusRequest`](/doc/models/update-current-cycle-status-request.md) | Body, Required | Request for updating the end date of the subscription current status |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-`void`
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-UpdateCurrentCycleStatusRequest request = new UpdateCurrentCycleStatusRequest();
-request.setStatus("status8");
-
-try {
-    Void response = subscriptionsController.updateCurrentCycleStatus(subscriptionId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -343,164 +112,6 @@ String discountId = "discount_id8";
 
 try {
     GetDiscountResponse response = subscriptionsController.deleteDiscount(subscriptionId, discountId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Subscription Items
-
-Get Subscription Items
-
-```java
-CompletableFuture<ListSubscriptionItemsResponse> getSubscriptionItems(
-    final String subscriptionId,
-    final Integer page,
-    final Integer size,
-    final String name,
-    final String code,
-    final String status,
-    final String description,
-    final String createdSince,
-    final String createdUntil)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | The subscription id |
-| `page` | `Integer` | Query, Optional | Page number |
-| `size` | `Integer` | Query, Optional | Page size |
-| `name` | `String` | Query, Optional | The item name |
-| `code` | `String` | Query, Optional | Identification code in the client system |
-| `status` | `String` | Query, Optional | The item statis |
-| `description` | `String` | Query, Optional | The item description |
-| `createdSince` | `String` | Query, Optional | Filter for item's creation date start range |
-| `createdUntil` | `String` | Query, Optional | Filter for item's creation date end range |
-
-## Response Type
-
-[`ListSubscriptionItemsResponse`](/doc/models/list-subscription-items-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-
-try {
-    ListSubscriptionItemsResponse response = subscriptionsController.getSubscriptionItems(subscriptionId, null, null, null, null, null, null, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Subscription Payment Method
-
-Updates the payment method from a subscription
-
-```java
-CompletableFuture<GetSubscriptionResponse> updateSubscriptionPaymentMethod(
-    final String subscriptionId,
-    final UpdateSubscriptionPaymentMethodRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription id |
-| `request` | [`UpdateSubscriptionPaymentMethodRequest`](/doc/models/update-subscription-payment-method-request.md) | Body, Required | Request for updating the paymentmethod from a subscription |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-UpdateSubscriptionPaymentMethodRequest request = new UpdateSubscriptionPaymentMethodRequest();
-request.setPaymentMethod("payment_method4");
-request.setCardId("card_id2");
-request.setCard(new CreateCardRequest());
-request.getCard().setNumber("number2");
-request.getCard().setHolderName("holder_name6");
-request.getCard().setExpMonth(80);
-request.getCard().setExpYear(216);
-request.getCard().setCvv("cvv8");
-request.getCard().setBillingAddress(new CreateAddressRequest());
-request.getCard().getBillingAddress().setStreet("street2");
-request.getCard().getBillingAddress().setNumber("number0");
-request.getCard().getBillingAddress().setZipCode("zip_code6");
-request.getCard().getBillingAddress().setNeighborhood("neighborhood8");
-request.getCard().getBillingAddress().setCity("city8");
-request.getCard().getBillingAddress().setState("state2");
-request.getCard().getBillingAddress().setCountry("country6");
-request.getCard().getBillingAddress().setComplement("complement2");
-request.getCard().getBillingAddress().setMetadata(new LinkedHashMap<>());
-request.getCard().getBillingAddress().getMetadata().put("key0", "metadata1");
-request.getCard().getBillingAddress().setLine1("line_14");
-request.getCard().getBillingAddress().setLine2("line_20");
-request.getCard().setBrand("brand4");
-request.getCard().setBillingAddressId("billing_address_id6");
-request.getCard().setMetadata(new LinkedHashMap<>());
-request.getCard().getMetadata().put("key0", "metadata3");
-request.getCard().getMetadata().put("key1", "metadata4");
-request.getCard().getMetadata().put("key2", "metadata5");
-request.getCard().setType("credit");
-request.getCard().setOptions(new CreateCardOptionsRequest());
-request.getCard().getOptions().setVerifyCard(false);
-request.getCard().setPrivateLabel(false);
-request.getCard().setLabel("label0");
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionPaymentMethod(subscriptionId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Subscription Item
-
-Get Subscription Item
-
-```java
-CompletableFuture<GetSubscriptionItemResponse> getSubscriptionItem(
-    final String subscriptionId,
-    final String itemId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription Id |
-| `itemId` | `String` | Template, Required | Item id |
-
-## Response Type
-
-[`GetSubscriptionItemResponse`](/doc/models/get-subscription-item-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-String itemId = "item_id0";
-
-try {
-    GetSubscriptionItemResponse response = subscriptionsController.getSubscriptionItem(subscriptionId, itemId);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -555,133 +166,6 @@ CompletableFuture<ListSubscriptionsResponse> getSubscriptions(
 ```java
 try {
     ListSubscriptionsResponse response = subscriptionsController.getSubscriptions(null, null, null, null, null, null, null, null, null, null, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Cancel Subscription
-
-Cancels a subscription
-
-```java
-CompletableFuture<GetSubscriptionResponse> cancelSubscription(
-    final String subscriptionId,
-    final CreateCancelSubscriptionRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription id |
-| `request` | [`CreateCancelSubscriptionRequest`](/doc/models/create-cancel-subscription-request.md) | Body, Optional | Request for cancelling a subscription |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-CreateCancelSubscriptionRequest request = new CreateCancelSubscriptionRequest();
-request.setCancelPendingInvoices(true);
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.cancelSubscription(subscriptionId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Create Increment
-
-Creates a increment
-
-```java
-CompletableFuture<GetIncrementResponse> createIncrement(
-    final String subscriptionId,
-    final CreateIncrementRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription id |
-| `request` | [`CreateIncrementRequest`](/doc/models/create-increment-request.md) | Body, Required | Request for creating a increment |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetIncrementResponse`](/doc/models/get-increment-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-CreateIncrementRequest request = new CreateIncrementRequest();
-request.setValue(185.28);
-request.setIncrementType("increment_type8");
-request.setItemId("item_id6");
-
-try {
-    GetIncrementResponse response = subscriptionsController.createIncrement(subscriptionId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Create Usage
-
-Creates a usage
-
-```java
-CompletableFuture<GetUsageResponse> createUsage(
-    final String subscriptionId,
-    final String itemId,
-    final CreateUsageRequest body,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription Id |
-| `itemId` | `String` | Template, Required | Item id |
-| `body` | [`CreateUsageRequest`](/doc/models/create-usage-request.md) | Body, Required | Request for creating a usage |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetUsageResponse`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-String itemId = "item_id0";
-CreateUsageRequest body = new CreateUsageRequest();
-body.setQuantity(156);
-body.setDescription("description4");
-body.setUsedAt(LocalDateTime.parse("2016-03-13T12:52:32.123Z", DateTimeFormatter.ISO_DATE_TIME));
-
-try {
-    GetUsageResponse response = subscriptionsController.createUsage(subscriptionId, itemId, body, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -1038,44 +522,6 @@ try {
 ```
 
 
-# Update Subscription Affiliation Id
-
-```java
-CompletableFuture<GetSubscriptionResponse> updateSubscriptionAffiliationId(
-    final String subscriptionId,
-    final UpdateSubscriptionAffiliationIdRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | - |
-| `request` | [`UpdateSubscriptionAffiliationIdRequest`](/doc/models/update-subscription-affiliation-id-request.md) | Body, Required | Request for updating a subscription affiliation id |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-UpdateSubscriptionAffiliationIdRequest request = new UpdateSubscriptionAffiliationIdRequest();
-request.setGatewayAffiliationId("gateway_affiliation_id2");
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionAffiliationId(subscriptionId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
 # Update Subscription Metadata
 
 Updates the metadata from a subscription
@@ -1156,13 +602,84 @@ try {
 ```
 
 
-# Get Subscription Cycles
+# Get Subscription
+
+Gets a subscription
 
 ```java
-CompletableFuture<ListCyclesResponse> getSubscriptionCycles(
+CompletableFuture<GetSubscriptionResponse> getSubscription(
+    final String subscriptionId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription id |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.getSubscription(subscriptionId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Latest Period End At
+
+```java
+CompletableFuture<GetSubscriptionResponse> updateLatestPeriodEndAt(
     final String subscriptionId,
-    final String page,
-    final String size)
+    final UpdateCurrentCycleEndDateRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | - |
+| `request` | [`UpdateCurrentCycleEndDateRequest`](/doc/models/update-current-cycle-end-date-request.md) | Body, Required | Request for updating the end date of the current signature cycle |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+UpdateCurrentCycleEndDateRequest request = new UpdateCurrentCycleEndDateRequest();
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.updateLatestPeriodEndAt(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Current Cycle Status
+
+```java
+CompletableFuture<Void> updateCurrentCycleStatus(
+    final String subscriptionId,
+    final UpdateCurrentCycleStatusRequest request,
+    final String idempotencyKey)
 ```
 
 ## Parameters
@@ -1170,22 +687,147 @@ CompletableFuture<ListCyclesResponse> getSubscriptionCycles(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `subscriptionId` | `String` | Template, Required | Subscription Id |
-| `page` | `String` | Query, Required | Page number |
-| `size` | `String` | Query, Required | Page size |
+| `request` | [`UpdateCurrentCycleStatusRequest`](/doc/models/update-current-cycle-status-request.md) | Body, Required | Request for updating the end date of the subscription current status |
+| `idempotencyKey` | `String` | Header, Optional | - |
 
 ## Response Type
 
-[`ListCyclesResponse`](/doc/models/list-cycles-response.md)
+`void`
 
 ## Example Usage
 
 ```java
 String subscriptionId = "subscription_id0";
-String page = "page8";
-String size = "size0";
+UpdateCurrentCycleStatusRequest request = new UpdateCurrentCycleStatusRequest();
+request.setStatus("status8");
 
 try {
-    ListCyclesResponse response = subscriptionsController.getSubscriptionCycles(subscriptionId, page, size);
+    Void response = subscriptionsController.updateCurrentCycleStatus(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Subscription Items
+
+Get Subscription Items
+
+```java
+CompletableFuture<ListSubscriptionItemsResponse> getSubscriptionItems(
+    final String subscriptionId,
+    final Integer page,
+    final Integer size,
+    final String name,
+    final String code,
+    final String status,
+    final String description,
+    final String createdSince,
+    final String createdUntil)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | The subscription id |
+| `page` | `Integer` | Query, Optional | Page number |
+| `size` | `Integer` | Query, Optional | Page size |
+| `name` | `String` | Query, Optional | The item name |
+| `code` | `String` | Query, Optional | Identification code in the client system |
+| `status` | `String` | Query, Optional | The item statis |
+| `description` | `String` | Query, Optional | The item description |
+| `createdSince` | `String` | Query, Optional | Filter for item's creation date start range |
+| `createdUntil` | `String` | Query, Optional | Filter for item's creation date end range |
+
+## Response Type
+
+[`ListSubscriptionItemsResponse`](/doc/models/list-subscription-items-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+
+try {
+    ListSubscriptionItemsResponse response = subscriptionsController.getSubscriptionItems(subscriptionId, null, null, null, null, null, null, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Subscription Item
+
+Get Subscription Item
+
+```java
+CompletableFuture<GetSubscriptionItemResponse> getSubscriptionItem(
+    final String subscriptionId,
+    final String itemId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription Id |
+| `itemId` | `String` | Template, Required | Item id |
+
+## Response Type
+
+[`GetSubscriptionItemResponse`](/doc/models/get-subscription-item-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+String itemId = "item_id0";
+
+try {
+    GetSubscriptionItemResponse response = subscriptionsController.getSubscriptionItem(subscriptionId, itemId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Subscription Affiliation Id
+
+```java
+CompletableFuture<GetSubscriptionResponse> updateSubscriptionAffiliationId(
+    final String subscriptionId,
+    final UpdateSubscriptionAffiliationIdRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | - |
+| `request` | [`UpdateSubscriptionAffiliationIdRequest`](/doc/models/update-subscription-affiliation-id-request.md) | Body, Required | Request for updating a subscription affiliation id |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+UpdateSubscriptionAffiliationIdRequest request = new UpdateSubscriptionAffiliationIdRequest();
+request.setGatewayAffiliationId("gateway_affiliation_id2");
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionAffiliationId(subscriptionId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -1224,201 +866,6 @@ int size = 18;
 
 try {
     ListDiscountsResponse response = subscriptionsController.getDiscounts(subscriptionId, page, size);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Subscription Billing Date
-
-Updates the billing date from a subscription
-
-```java
-CompletableFuture<GetSubscriptionResponse> updateSubscriptionBillingDate(
-    final String subscriptionId,
-    final UpdateSubscriptionBillingDateRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | The subscription id |
-| `request` | [`UpdateSubscriptionBillingDateRequest`](/doc/models/update-subscription-billing-date-request.md) | Body, Required | Request for updating the subscription billing date |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-UpdateSubscriptionBillingDateRequest request = new UpdateSubscriptionBillingDateRequest();
-request.setNextBillingAt(LocalDateTime.parse("2016-03-13T12:52:32.123Z", DateTimeFormatter.ISO_DATE_TIME));
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionBillingDate(subscriptionId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Delete Subscription Item
-
-Deletes a subscription item
-
-```java
-CompletableFuture<GetSubscriptionItemResponse> deleteSubscriptionItem(
-    final String subscriptionId,
-    final String subscriptionItemId,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription id |
-| `subscriptionItemId` | `String` | Template, Required | Subscription item id |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionItemResponse`](/doc/models/get-subscription-item-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-String subscriptionItemId = "subscription_item_id4";
-
-try {
-    GetSubscriptionItemResponse response = subscriptionsController.deleteSubscriptionItem(subscriptionId, subscriptionItemId, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Increments
-
-```java
-CompletableFuture<ListIncrementsResponse> getIncrements(
-    final String subscriptionId,
-    final Integer page,
-    final Integer size)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | The subscription id |
-| `page` | `Integer` | Query, Optional | Page number |
-| `size` | `Integer` | Query, Optional | Page size |
-
-## Response Type
-
-[`ListIncrementsResponse`](/doc/models/list-increments-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-
-try {
-    ListIncrementsResponse response = subscriptionsController.getIncrements(subscriptionId, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Subscription Due Days
-
-Updates the boleto due days from a subscription
-
-```java
-CompletableFuture<GetSubscriptionResponse> updateSubscriptionDueDays(
-    final String subscriptionId,
-    final UpdateSubscriptionDueDaysRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription Id |
-| `request` | [`UpdateSubscriptionDueDaysRequest`](/doc/models/update-subscription-due-days-request.md) | Body, Required | - |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-UpdateSubscriptionDueDaysRequest request = new UpdateSubscriptionDueDaysRequest();
-request.setBoletoDueDays(226);
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionDueDays(subscriptionId, request, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Subscription Start At
-
-Updates the start at date from a subscription
-
-```java
-CompletableFuture<GetSubscriptionResponse> updateSubscriptionStartAt(
-    final String subscriptionId,
-    final UpdateSubscriptionStartAtRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | The subscription id |
-| `request` | [`UpdateSubscriptionStartAtRequest`](/doc/models/update-subscription-start-at-request.md) | Body, Required | Request for updating the subscription start date |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-UpdateSubscriptionStartAtRequest request = new UpdateSubscriptionStartAtRequest();
-request.setStartAt(LocalDateTime.parse("2016-03-13T12:52:32.123Z", DateTimeFormatter.ISO_DATE_TIME));
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionStartAt(subscriptionId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -1552,40 +999,6 @@ try {
 ```
 
 
-# Get Subscription
-
-Gets a subscription
-
-```java
-CompletableFuture<GetSubscriptionResponse> getSubscription(
-    final String subscriptionId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | Subscription id |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.getSubscription(subscriptionId);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
 # Get Usages
 
 Lists all usages from a subscription item
@@ -1627,43 +1040,6 @@ String itemId = "item_id0";
 
 try {
     ListUsagesResponse response = subscriptionsController.getUsages(subscriptionId, itemId, null, null, null, null, null, null);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Update Latest Period End At
-
-```java
-CompletableFuture<GetSubscriptionResponse> updateLatestPeriodEndAt(
-    final String subscriptionId,
-    final UpdateCurrentCycleEndDateRequest request,
-    final String idempotencyKey)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `String` | Template, Required | - |
-| `request` | [`UpdateCurrentCycleEndDateRequest`](/doc/models/update-current-cycle-end-date-request.md) | Body, Required | Request for updating the end date of the current signature cycle |
-| `idempotencyKey` | `String` | Header, Optional | - |
-
-## Response Type
-
-[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```java
-String subscriptionId = "subscription_id0";
-UpdateCurrentCycleEndDateRequest request = new UpdateCurrentCycleEndDateRequest();
-
-try {
-    GetSubscriptionResponse response = subscriptionsController.updateLatestPeriodEndAt(subscriptionId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {
@@ -1738,6 +1114,630 @@ String cycleId = "cycleId0";
 
 try {
     GetPeriodResponse response = subscriptionsController.getSubscriptionCycleById(subscriptionId, cycleId);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Create an Usage
+
+Create Usage
+
+```java
+CompletableFuture<GetUsageResponse> createAnUsage(
+    final String subscriptionId,
+    final String itemId,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription id |
+| `itemId` | `String` | Template, Required | Item id |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetUsageResponse`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+String itemId = "item_id0";
+
+try {
+    GetUsageResponse response = subscriptionsController.createAnUsage(subscriptionId, itemId, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Cancel Subscription
+
+Cancels a subscription
+
+```java
+CompletableFuture<GetSubscriptionResponse> cancelSubscription(
+    final String subscriptionId,
+    final CreateCancelSubscriptionRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription id |
+| `request` | [`CreateCancelSubscriptionRequest`](/doc/models/create-cancel-subscription-request.md) | Body, Optional | Request for cancelling a subscription |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+CreateCancelSubscriptionRequest request = new CreateCancelSubscriptionRequest();
+request.setCancelPendingInvoices(true);
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.cancelSubscription(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Delete Subscription Item
+
+Deletes a subscription item
+
+```java
+CompletableFuture<GetSubscriptionItemResponse> deleteSubscriptionItem(
+    final String subscriptionId,
+    final String subscriptionItemId,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription id |
+| `subscriptionItemId` | `String` | Template, Required | Subscription item id |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionItemResponse`](/doc/models/get-subscription-item-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+String subscriptionItemId = "subscription_item_id4";
+
+try {
+    GetSubscriptionItemResponse response = subscriptionsController.deleteSubscriptionItem(subscriptionId, subscriptionItemId, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Increments
+
+```java
+CompletableFuture<ListIncrementsResponse> getIncrements(
+    final String subscriptionId,
+    final Integer page,
+    final Integer size)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | The subscription id |
+| `page` | `Integer` | Query, Optional | Page number |
+| `size` | `Integer` | Query, Optional | Page size |
+
+## Response Type
+
+[`ListIncrementsResponse`](/doc/models/list-increments-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+
+try {
+    ListIncrementsResponse response = subscriptionsController.getIncrements(subscriptionId, null, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Subscription Due Days
+
+Updates the boleto due days from a subscription
+
+```java
+CompletableFuture<GetSubscriptionResponse> updateSubscriptionDueDays(
+    final String subscriptionId,
+    final UpdateSubscriptionDueDaysRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription Id |
+| `request` | [`UpdateSubscriptionDueDaysRequest`](/doc/models/update-subscription-due-days-request.md) | Body, Required | - |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+UpdateSubscriptionDueDaysRequest request = new UpdateSubscriptionDueDaysRequest();
+request.setBoletoDueDays(226);
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionDueDays(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Subscription Card
+
+Updates the credit card from a subscription
+
+```java
+CompletableFuture<GetSubscriptionResponse> updateSubscriptionCard(
+    final String subscriptionId,
+    final UpdateSubscriptionCardRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription id |
+| `request` | [`UpdateSubscriptionCardRequest`](/doc/models/update-subscription-card-request.md) | Body, Required | Request for updating a card |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+UpdateSubscriptionCardRequest request = new UpdateSubscriptionCardRequest();
+request.setCard(new CreateCardRequest());
+request.getCard().setNumber("number2");
+request.getCard().setHolderName("holder_name6");
+request.getCard().setExpMonth(80);
+request.getCard().setExpYear(216);
+request.getCard().setCvv("cvv8");
+request.getCard().setBillingAddress(new CreateAddressRequest());
+request.getCard().getBillingAddress().setStreet("street2");
+request.getCard().getBillingAddress().setNumber("number0");
+request.getCard().getBillingAddress().setZipCode("zip_code6");
+request.getCard().getBillingAddress().setNeighborhood("neighborhood8");
+request.getCard().getBillingAddress().setCity("city8");
+request.getCard().getBillingAddress().setState("state2");
+request.getCard().getBillingAddress().setCountry("country6");
+request.getCard().getBillingAddress().setComplement("complement2");
+request.getCard().getBillingAddress().setMetadata(new LinkedHashMap<>());
+request.getCard().getBillingAddress().getMetadata().put("key0", "metadata1");
+request.getCard().getBillingAddress().setLine1("line_14");
+request.getCard().getBillingAddress().setLine2("line_20");
+request.getCard().setBrand("brand4");
+request.getCard().setBillingAddressId("billing_address_id6");
+request.getCard().setMetadata(new LinkedHashMap<>());
+request.getCard().getMetadata().put("key0", "metadata3");
+request.getCard().getMetadata().put("key1", "metadata4");
+request.getCard().getMetadata().put("key2", "metadata5");
+request.getCard().setType("credit");
+request.getCard().setOptions(new CreateCardOptionsRequest());
+request.getCard().getOptions().setVerifyCard(false);
+request.getCard().setPrivateLabel(false);
+request.getCard().setLabel("label0");
+request.setCardId("card_id2");
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionCard(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Delete Usage
+
+Deletes a usage
+
+```java
+CompletableFuture<GetUsageResponse> deleteUsage(
+    final String subscriptionId,
+    final String itemId,
+    final String usageId,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | The subscription id |
+| `itemId` | `String` | Template, Required | The subscription item id |
+| `usageId` | `String` | Template, Required | The usage id |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetUsageResponse`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+String itemId = "item_id0";
+String usageId = "usage_id0";
+
+try {
+    GetUsageResponse response = subscriptionsController.deleteUsage(subscriptionId, itemId, usageId, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Create Discount
+
+Creates a discount
+
+```java
+CompletableFuture<GetDiscountResponse> createDiscount(
+    final String subscriptionId,
+    final CreateDiscountRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription id |
+| `request` | [`CreateDiscountRequest`](/doc/models/create-discount-request.md) | Body, Required | Request for creating a discount |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetDiscountResponse`](/doc/models/get-discount-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+CreateDiscountRequest request = new CreateDiscountRequest();
+request.setValue(185.28);
+request.setDiscountType("discount_type4");
+request.setItemId("item_id6");
+
+try {
+    GetDiscountResponse response = subscriptionsController.createDiscount(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Subscription Payment Method
+
+Updates the payment method from a subscription
+
+```java
+CompletableFuture<GetSubscriptionResponse> updateSubscriptionPaymentMethod(
+    final String subscriptionId,
+    final UpdateSubscriptionPaymentMethodRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription id |
+| `request` | [`UpdateSubscriptionPaymentMethodRequest`](/doc/models/update-subscription-payment-method-request.md) | Body, Required | Request for updating the paymentmethod from a subscription |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+UpdateSubscriptionPaymentMethodRequest request = new UpdateSubscriptionPaymentMethodRequest();
+request.setPaymentMethod("payment_method4");
+request.setCardId("card_id2");
+request.setCard(new CreateCardRequest());
+request.getCard().setNumber("number2");
+request.getCard().setHolderName("holder_name6");
+request.getCard().setExpMonth(80);
+request.getCard().setExpYear(216);
+request.getCard().setCvv("cvv8");
+request.getCard().setBillingAddress(new CreateAddressRequest());
+request.getCard().getBillingAddress().setStreet("street2");
+request.getCard().getBillingAddress().setNumber("number0");
+request.getCard().getBillingAddress().setZipCode("zip_code6");
+request.getCard().getBillingAddress().setNeighborhood("neighborhood8");
+request.getCard().getBillingAddress().setCity("city8");
+request.getCard().getBillingAddress().setState("state2");
+request.getCard().getBillingAddress().setCountry("country6");
+request.getCard().getBillingAddress().setComplement("complement2");
+request.getCard().getBillingAddress().setMetadata(new LinkedHashMap<>());
+request.getCard().getBillingAddress().getMetadata().put("key0", "metadata1");
+request.getCard().getBillingAddress().setLine1("line_14");
+request.getCard().getBillingAddress().setLine2("line_20");
+request.getCard().setBrand("brand4");
+request.getCard().setBillingAddressId("billing_address_id6");
+request.getCard().setMetadata(new LinkedHashMap<>());
+request.getCard().getMetadata().put("key0", "metadata3");
+request.getCard().getMetadata().put("key1", "metadata4");
+request.getCard().getMetadata().put("key2", "metadata5");
+request.getCard().setType("credit");
+request.getCard().setOptions(new CreateCardOptionsRequest());
+request.getCard().getOptions().setVerifyCard(false);
+request.getCard().setPrivateLabel(false);
+request.getCard().setLabel("label0");
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionPaymentMethod(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Create Increment
+
+Creates a increment
+
+```java
+CompletableFuture<GetIncrementResponse> createIncrement(
+    final String subscriptionId,
+    final CreateIncrementRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription id |
+| `request` | [`CreateIncrementRequest`](/doc/models/create-increment-request.md) | Body, Required | Request for creating a increment |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetIncrementResponse`](/doc/models/get-increment-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+CreateIncrementRequest request = new CreateIncrementRequest();
+request.setValue(185.28);
+request.setIncrementType("increment_type8");
+request.setItemId("item_id6");
+
+try {
+    GetIncrementResponse response = subscriptionsController.createIncrement(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Create Usage
+
+Creates a usage
+
+```java
+CompletableFuture<GetUsageResponse> createUsage(
+    final String subscriptionId,
+    final String itemId,
+    final CreateUsageRequest body,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription Id |
+| `itemId` | `String` | Template, Required | Item id |
+| `body` | [`CreateUsageRequest`](/doc/models/create-usage-request.md) | Body, Required | Request for creating a usage |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetUsageResponse`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+String itemId = "item_id0";
+CreateUsageRequest body = new CreateUsageRequest();
+body.setQuantity(156);
+body.setDescription("description4");
+body.setUsedAt(LocalDateTime.parse("2016-03-13T12:52:32.123Z", DateTimeFormatter.ISO_DATE_TIME));
+
+try {
+    GetUsageResponse response = subscriptionsController.createUsage(subscriptionId, itemId, body, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Get Subscription Cycles
+
+```java
+CompletableFuture<ListCyclesResponse> getSubscriptionCycles(
+    final String subscriptionId,
+    final String page,
+    final String size)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | Subscription Id |
+| `page` | `String` | Query, Required | Page number |
+| `size` | `String` | Query, Required | Page size |
+
+## Response Type
+
+[`ListCyclesResponse`](/doc/models/list-cycles-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+String page = "page8";
+String size = "size0";
+
+try {
+    ListCyclesResponse response = subscriptionsController.getSubscriptionCycles(subscriptionId, page, size);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Subscription Billing Date
+
+Updates the billing date from a subscription
+
+```java
+CompletableFuture<GetSubscriptionResponse> updateSubscriptionBillingDate(
+    final String subscriptionId,
+    final UpdateSubscriptionBillingDateRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | The subscription id |
+| `request` | [`UpdateSubscriptionBillingDateRequest`](/doc/models/update-subscription-billing-date-request.md) | Body, Required | Request for updating the subscription billing date |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+UpdateSubscriptionBillingDateRequest request = new UpdateSubscriptionBillingDateRequest();
+request.setNextBillingAt(LocalDateTime.parse("2016-03-13T12:52:32.123Z", DateTimeFormatter.ISO_DATE_TIME));
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionBillingDate(subscriptionId, request, null);
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+# Update Subscription Start At
+
+Updates the start at date from a subscription
+
+```java
+CompletableFuture<GetSubscriptionResponse> updateSubscriptionStartAt(
+    final String subscriptionId,
+    final UpdateSubscriptionStartAtRequest request,
+    final String idempotencyKey)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `String` | Template, Required | The subscription id |
+| `request` | [`UpdateSubscriptionStartAtRequest`](/doc/models/update-subscription-start-at-request.md) | Body, Required | Request for updating the subscription start date |
+| `idempotencyKey` | `String` | Header, Optional | - |
+
+## Response Type
+
+[`GetSubscriptionResponse`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```java
+String subscriptionId = "subscription_id0";
+UpdateSubscriptionStartAtRequest request = new UpdateSubscriptionStartAtRequest();
+request.setStartAt(LocalDateTime.parse("2016-03-13T12:52:32.123Z", DateTimeFormatter.ISO_DATE_TIME));
+
+try {
+    GetSubscriptionResponse response = subscriptionsController.updateSubscriptionStartAt(subscriptionId, request, null);
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/controllers/transfers.md
+++ b/doc/controllers/transfers.md
@@ -10,9 +10,34 @@ TransfersController transfersController = client.getTransfersController();
 
 ## Methods
 
+* [Get Transfers](/doc/controllers/transfers.md#get-transfers)
 * [Get Transfer by Id](/doc/controllers/transfers.md#get-transfer-by-id)
 * [Create Transfer](/doc/controllers/transfers.md#create-transfer)
-* [Get Transfers](/doc/controllers/transfers.md#get-transfers)
+
+
+# Get Transfers
+
+Gets all transfers
+
+```java
+CompletableFuture<ListTransfers> getTransfers()
+```
+
+## Response Type
+
+[`ListTransfers`](/doc/models/list-transfers.md)
+
+## Example Usage
+
+```java
+try {
+    ListTransfers response = transfersController.getTransfers();
+} catch (ApiException e) {
+    e.printStackTrace();
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
 
 
 # Get Transfer by Id
@@ -74,31 +99,6 @@ request.setTargetId("target_id6");
 
 try {
     GetTransfer response = transfersController.createTransfer(request);
-} catch (ApiException e) {
-    e.printStackTrace();
-} catch (IOException e) {
-    e.printStackTrace();
-}
-```
-
-
-# Get Transfers
-
-Gets all transfers
-
-```java
-CompletableFuture<ListTransfers> getTransfers()
-```
-
-## Response Type
-
-[`ListTransfers`](/doc/models/list-transfers.md)
-
-## Example Usage
-
-```java
-try {
-    ListTransfers response = transfersController.getTransfers();
 } catch (ApiException e) {
     e.printStackTrace();
 } catch (IOException e) {

--- a/doc/models/create-order-item-request.md
+++ b/doc/models/create-order-item-request.md
@@ -14,8 +14,6 @@ Request for creating an order item
 | `Amount` | `int` | Required | Amount | int getAmount() | setAmount(int amount) |
 | `Description` | `String` | Required | Description | String getDescription() | setDescription(String description) |
 | `Quantity` | `int` | Required | Quantity | int getQuantity() | setQuantity(int quantity) |
-| `Seller` | [`CreateSellerRequest`](/doc/models/create-seller-request.md) | Optional | Item seller | CreateSellerRequest getSeller() | setSeller(CreateSellerRequest seller) |
-| `SellerId` | `String` | Optional | seller identificator | String getSellerId() | setSellerId(String sellerId) |
 | `Category` | `String` | Required | Category | String getCategory() | setCategory(String category) |
 | `Code` | `String` | Optional | The item code passed by the client | String getCode() | setCode(String code) |
 
@@ -26,8 +24,6 @@ Request for creating an order item
   "amount": 46,
   "description": "description0",
   "quantity": 68,
-  "seller": null,
-  "seller_id": null,
   "category": "category2",
   "code": null
 }

--- a/doc/models/get-order-item-response.md
+++ b/doc/models/get-order-item-response.md
@@ -15,7 +15,6 @@ Response object for getting an order item
 | `Amount` | `int` | Required | - | int getAmount() | setAmount(int amount) |
 | `Description` | `String` | Required | - | String getDescription() | setDescription(String description) |
 | `Quantity` | `int` | Required | - | int getQuantity() | setQuantity(int quantity) |
-| `GetSellerResponse` | [`GetSellerResponse`](/doc/models/get-seller-response.md) | Optional | Seller data | GetSellerResponse getGetSellerResponse() | setGetSellerResponse(GetSellerResponse getSellerResponse) |
 | `Category` | `String` | Required | Category | String getCategory() | setCategory(String category) |
 | `Code` | `String` | Required | Code | String getCode() | setCode(String code) |
 
@@ -27,7 +26,6 @@ Response object for getting an order item
   "amount": 46,
   "description": "description0",
   "quantity": 68,
-  "GetSellerResponse": null,
   "category": "category2",
   "code": "code8"
 }

--- a/doc/models/get-order-response.md
+++ b/doc/models/get-order-response.md
@@ -43,7 +43,6 @@ Response object for getting an Order
       "amount": 13,
       "description": "description7",
       "quantity": 127,
-      "GetSellerResponse": null,
       "category": "category5",
       "code": "code5"
     },
@@ -52,7 +51,6 @@ Response object for getting an Order
       "amount": 14,
       "description": "description8",
       "quantity": 128,
-      "GetSellerResponse": null,
       "category": "category6",
       "code": "code6"
     }

--- a/doc/models/list-order-response.md
+++ b/doc/models/list-order-response.md
@@ -29,7 +29,6 @@ Response object for listing order objects
           "amount": 180,
           "description": "description2",
           "quantity": 38,
-          "GetSellerResponse": null,
           "category": "category0",
           "code": "code0"
         },
@@ -38,7 +37,6 @@ Response object for listing order objects
           "amount": 181,
           "description": "description3",
           "quantity": 39,
-          "GetSellerResponse": null,
           "category": "category1",
           "code": "code1"
         }
@@ -173,7 +171,6 @@ Response object for listing order objects
           "amount": 181,
           "description": "description3",
           "quantity": 39,
-          "GetSellerResponse": null,
           "category": "category1",
           "code": "code1"
         },
@@ -182,7 +179,6 @@ Response object for listing order objects
           "amount": 182,
           "description": "description4",
           "quantity": 40,
-          "GetSellerResponse": null,
           "category": "category2",
           "code": "code2"
         },
@@ -191,7 +187,6 @@ Response object for listing order objects
           "amount": 183,
           "description": "description5",
           "quantity": 41,
-          "GetSellerResponse": null,
           "category": "category3",
           "code": "code3"
         }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>PagarmeApiSDKLib</groupId>
   <artifactId>pagarme-api-sdklib</artifactId>
-  <version>6.1.0-alpha</version>
+  <version>6.2.0</version>
   <packaging>jar</packaging>
 
   <name>PagarmeApiSDKLib</name>

--- a/src/main/java/me/pagar/api/Configuration.java
+++ b/src/main/java/me/pagar/api/Configuration.java
@@ -20,8 +20,7 @@ public interface Configuration {
     Environment getEnvironment();
 
     /**
-     * Http Client Configuration instance. 
-     * See available [builder methods here](__HttpClientConfiguration.Builder).
+     * Http Client Configuration instance.
      * @return a copy of httpClientConfig
      */
     ReadonlyHttpClientConfiguration getHttpClientConfig();

--- a/src/main/java/me/pagar/api/PagarmeApiSDKClient.java
+++ b/src/main/java/me/pagar/api/PagarmeApiSDKClient.java
@@ -17,7 +17,6 @@ import me.pagar.api.controllers.DefaultInvoicesController;
 import me.pagar.api.controllers.DefaultOrdersController;
 import me.pagar.api.controllers.DefaultPlansController;
 import me.pagar.api.controllers.DefaultRecipientsController;
-import me.pagar.api.controllers.DefaultSellersController;
 import me.pagar.api.controllers.DefaultSubscriptionsController;
 import me.pagar.api.controllers.DefaultTokensController;
 import me.pagar.api.controllers.DefaultTransactionsController;
@@ -26,7 +25,6 @@ import me.pagar.api.controllers.InvoicesController;
 import me.pagar.api.controllers.OrdersController;
 import me.pagar.api.controllers.PlansController;
 import me.pagar.api.controllers.RecipientsController;
-import me.pagar.api.controllers.SellersController;
 import me.pagar.api.controllers.SubscriptionsController;
 import me.pagar.api.controllers.TokensController;
 import me.pagar.api.controllers.TransactionsController;
@@ -46,16 +44,15 @@ public final class PagarmeApiSDKClient implements PagarmeApiSDKClientInterface {
     /**
      * Private store for controllers.
      */
+    private OrdersController orders;
     private PlansController plans;
     private SubscriptionsController subscriptions;
     private InvoicesController invoices;
-    private OrdersController orders;
     private CustomersController customers;
     private RecipientsController recipients;
     private ChargesController charges;
-    private TransfersController transfers;
     private TokensController tokens;
-    private SellersController sellers;
+    private TransfersController transfers;
     private TransactionsController transactions;
 
     /**
@@ -101,17 +98,16 @@ public final class PagarmeApiSDKClient implements PagarmeApiSDKClientInterface {
             this.authManagers.put("global", basicAuthManager);
         }
 
+        orders = new DefaultOrdersController(this, this.httpClient, this.authManagers);
         plans = new DefaultPlansController(this, this.httpClient, this.authManagers);
         subscriptions = new DefaultSubscriptionsController(this, this.httpClient,
                 this.authManagers);
         invoices = new DefaultInvoicesController(this, this.httpClient, this.authManagers);
-        orders = new DefaultOrdersController(this, this.httpClient, this.authManagers);
         customers = new DefaultCustomersController(this, this.httpClient, this.authManagers);
         recipients = new DefaultRecipientsController(this, this.httpClient, this.authManagers);
         charges = new DefaultChargesController(this, this.httpClient, this.authManagers);
-        transfers = new DefaultTransfersController(this, this.httpClient, this.authManagers);
         tokens = new DefaultTokensController(this, this.httpClient, this.authManagers);
-        sellers = new DefaultSellersController(this, this.httpClient, this.authManagers);
+        transfers = new DefaultTransfersController(this, this.httpClient, this.authManagers);
         transactions = new DefaultTransactionsController(this, this.httpClient, this.authManagers);
     }
 
@@ -120,6 +116,14 @@ public final class PagarmeApiSDKClient implements PagarmeApiSDKClientInterface {
      */
     public static void shutdown() {
         OkClient.shutdown();
+    }
+
+    /**
+     * Get the instance of OrdersController.
+     * @return orders
+     */
+    public OrdersController getOrdersController() {
+        return orders;
     }
 
     /**
@@ -147,14 +151,6 @@ public final class PagarmeApiSDKClient implements PagarmeApiSDKClientInterface {
     }
 
     /**
-     * Get the instance of OrdersController.
-     * @return orders
-     */
-    public OrdersController getOrdersController() {
-        return orders;
-    }
-
-    /**
      * Get the instance of CustomersController.
      * @return customers
      */
@@ -179,14 +175,6 @@ public final class PagarmeApiSDKClient implements PagarmeApiSDKClientInterface {
     }
 
     /**
-     * Get the instance of TransfersController.
-     * @return transfers
-     */
-    public TransfersController getTransfersController() {
-        return transfers;
-    }
-
-    /**
      * Get the instance of TokensController.
      * @return tokens
      */
@@ -195,11 +183,11 @@ public final class PagarmeApiSDKClient implements PagarmeApiSDKClientInterface {
     }
 
     /**
-     * Get the instance of SellersController.
-     * @return sellers
+     * Get the instance of TransfersController.
+     * @return transfers
      */
-    public SellersController getSellersController() {
-        return sellers;
+    public TransfersController getTransfersController() {
+        return transfers;
     }
 
     /**

--- a/src/main/java/me/pagar/api/PagarmeApiSDKClientInterface.java
+++ b/src/main/java/me/pagar/api/PagarmeApiSDKClientInterface.java
@@ -12,7 +12,6 @@ import me.pagar.api.controllers.InvoicesController;
 import me.pagar.api.controllers.OrdersController;
 import me.pagar.api.controllers.PlansController;
 import me.pagar.api.controllers.RecipientsController;
-import me.pagar.api.controllers.SellersController;
 import me.pagar.api.controllers.SubscriptionsController;
 import me.pagar.api.controllers.TokensController;
 import me.pagar.api.controllers.TransactionsController;
@@ -25,6 +24,12 @@ import me.pagar.api.controllers.TransfersController;
  */
 public interface PagarmeApiSDKClientInterface extends Configuration {
     
+    /**
+     * Provides access to Orders controller.
+     * @return Returns the OrdersController instance
+     */
+    OrdersController getOrdersController();
+
     /**
      * Provides access to Plans controller.
      * @return Returns the PlansController instance
@@ -42,12 +47,6 @@ public interface PagarmeApiSDKClientInterface extends Configuration {
      * @return Returns the InvoicesController instance
      */
     InvoicesController getInvoicesController();
-
-    /**
-     * Provides access to Orders controller.
-     * @return Returns the OrdersController instance
-     */
-    OrdersController getOrdersController();
 
     /**
      * Provides access to Customers controller.
@@ -68,22 +67,16 @@ public interface PagarmeApiSDKClientInterface extends Configuration {
     ChargesController getChargesController();
 
     /**
-     * Provides access to Transfers controller.
-     * @return Returns the TransfersController instance
-     */
-    TransfersController getTransfersController();
-
-    /**
      * Provides access to Tokens controller.
      * @return Returns the TokensController instance
      */
     TokensController getTokensController();
 
     /**
-     * Provides access to Sellers controller.
-     * @return Returns the SellersController instance
+     * Provides access to Transfers controller.
+     * @return Returns the TransfersController instance
      */
-    SellersController getSellersController();
+    TransfersController getTransfersController();
 
     /**
      * Provides access to Transactions controller.

--- a/src/main/java/me/pagar/api/controllers/BaseController.java
+++ b/src/main/java/me/pagar/api/controllers/BaseController.java
@@ -23,7 +23,7 @@ import me.pagar.api.http.response.HttpResponse;
  * Base class for all Controllers.
  */
 public abstract class BaseController {
-    protected static String userAgent = "PagarmeCoreApi - Java 6.1.0-alpha.0";
+    protected static String userAgent = "PagarmeCoreApi - Java 6.2.0";
 
     /**
      * Protected variables to hold an instance of Configuration.

--- a/src/main/java/me/pagar/api/controllers/ChargesController.java
+++ b/src/main/java/me/pagar/api/controllers/ChargesController.java
@@ -56,6 +56,45 @@ public interface ChargesController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
+     * Updates the card from a charge.
+     * @param  chargeId  Required parameter: Charge id
+     * @param  request  Required parameter: Request for updating a charge's card
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetChargeResponse updateChargeCard(
+            final String chargeId,
+            final UpdateChargeCardRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * @param  status  Required parameter: Example:
+     * @param  createdSince  Optional parameter: Example:
+     * @param  createdUntil  Optional parameter: Example:
+     * @return    Returns the GetChargesSummaryResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetChargesSummaryResponse getChargesSummary(
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) throws ApiException, IOException;
+
+    /**
+     * Creates a new charge.
+     * @param  request  Required parameter: Request for creating a charge
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetChargeResponse createCharge(
+            final CreateChargeRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
      * @param  chargeId  Required parameter: Charge Id
      * @param  page  Optional parameter: Page number
      * @param  size  Optional parameter: Page size
@@ -69,17 +108,41 @@ public interface ChargesController {
             final Integer size) throws ApiException, IOException;
 
     /**
-     * Updates the due date from a charge.
-     * @param  chargeId  Required parameter: Charge Id
-     * @param  request  Required parameter: Request for updating the due date
+     * Captures a charge.
+     * @param  chargeId  Required parameter: Charge id
+     * @param  request  Optional parameter: Request for capturing a charge
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetChargeResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetChargeResponse updateChargeDueDate(
+    GetChargeResponse captureCharge(
             final String chargeId,
-            final UpdateChargeDueDateRequest request,
+            final CreateCaptureChargeRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Get a charge from its id.
+     * @param  chargeId  Required parameter: Charge id
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetChargeResponse getCharge(
+            final String chargeId) throws ApiException, IOException;
+
+    /**
+     * Cancel a charge.
+     * @param  chargeId  Required parameter: Charge id
+     * @param  request  Optional parameter: Request for cancelling a charge
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetChargeResponse cancelCharge(
+            final String chargeId,
+            final CreateCancelChargeRequest request,
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
@@ -111,55 +174,31 @@ public interface ChargesController {
             final LocalDateTime createdUntil) throws ApiException, IOException;
 
     /**
-     * Captures a charge.
-     * @param  chargeId  Required parameter: Charge id
-     * @param  request  Optional parameter: Request for capturing a charge
+     * @param  chargeId  Required parameter: Example:
+     * @param  request  Optional parameter: Request for confirm payment
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetChargeResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetChargeResponse captureCharge(
+    GetChargeResponse confirmPayment(
             final String chargeId,
-            final CreateCaptureChargeRequest request,
+            final CreateConfirmPaymentRequest request,
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
-     * Updates the card from a charge.
-     * @param  chargeId  Required parameter: Charge id
-     * @param  request  Required parameter: Request for updating a charge's card
+     * Updates the due date from a charge.
+     * @param  chargeId  Required parameter: Charge Id
+     * @param  request  Required parameter: Request for updating the due date
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetChargeResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetChargeResponse updateChargeCard(
+    GetChargeResponse updateChargeDueDate(
             final String chargeId,
-            final UpdateChargeCardRequest request,
+            final UpdateChargeDueDateRequest request,
             final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Get a charge from its id.
-     * @param  chargeId  Required parameter: Charge id
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetChargeResponse getCharge(
-            final String chargeId) throws ApiException, IOException;
-
-    /**
-     * @param  status  Required parameter: Example:
-     * @param  createdSince  Optional parameter: Example:
-     * @param  createdUntil  Optional parameter: Example:
-     * @return    Returns the GetChargesSummaryResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetChargesSummaryResponse getChargesSummary(
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) throws ApiException, IOException;
 
     /**
      * Retries a charge.
@@ -171,45 +210,6 @@ public interface ChargesController {
      */
     GetChargeResponse retryCharge(
             final String chargeId,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Cancel a charge.
-     * @param  chargeId  Required parameter: Charge id
-     * @param  request  Optional parameter: Request for cancelling a charge
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetChargeResponse cancelCharge(
-            final String chargeId,
-            final CreateCancelChargeRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Creates a new charge.
-     * @param  request  Required parameter: Request for creating a charge
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetChargeResponse createCharge(
-            final CreateChargeRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * @param  chargeId  Required parameter: Example:
-     * @param  request  Optional parameter: Request for confirm payment
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetChargeResponse confirmPayment(
-            final String chargeId,
-            final CreateConfirmPaymentRequest request,
             final String idempotencyKey) throws ApiException, IOException;
 
 }

--- a/src/main/java/me/pagar/api/controllers/CustomersController.java
+++ b/src/main/java/me/pagar/api/controllers/CustomersController.java
@@ -77,18 +77,6 @@ public interface CustomersController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
-     * Creates a new customer.
-     * @param  request  Required parameter: Request for creating a customer
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetCustomerResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetCustomerResponse createCustomer(
-            final CreateCustomerRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
      * Creates a new address for a customer.
      * @param  customerId  Required parameter: Customer Id
      * @param  request  Required parameter: Request for creating an address
@@ -103,14 +91,58 @@ public interface CustomersController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
-     * Delete a Customer's access tokens.
-     * @param  customerId  Required parameter: Customer Id
-     * @return    Returns the ListAccessTokensResponse response from the API call
+     * Creates a new customer.
+     * @param  request  Required parameter: Request for creating a customer
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetCustomerResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    ListAccessTokensResponse deleteAccessTokens(
-            final String customerId) throws ApiException, IOException;
+    GetCustomerResponse createCustomer(
+            final CreateCustomerRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Creates a new card for a customer.
+     * @param  customerId  Required parameter: Customer id
+     * @param  request  Required parameter: Request for creating a card
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetCardResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetCardResponse createCard(
+            final String customerId,
+            final CreateCardRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Get all cards from a customer.
+     * @param  customerId  Required parameter: Customer Id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @return    Returns the ListCardsResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListCardsResponse getCards(
+            final String customerId,
+            final Integer page,
+            final Integer size) throws ApiException, IOException;
+
+    /**
+     * Renew a card.
+     * @param  customerId  Required parameter: Customer id
+     * @param  cardId  Required parameter: Card Id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetCardResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetCardResponse renewCard(
+            final String customerId,
+            final String cardId,
+            final String idempotencyKey) throws ApiException, IOException;
 
     /**
      * Get a customer's address.
@@ -139,18 +171,80 @@ public interface CustomersController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
-     * Creates a new card for a customer.
-     * @param  customerId  Required parameter: Customer id
-     * @param  request  Required parameter: Request for creating a card
+     * Get a Customer's access token.
+     * @param  customerId  Required parameter: Customer Id
+     * @param  tokenId  Required parameter: Token Id
+     * @return    Returns the GetAccessTokenResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetAccessTokenResponse getAccessToken(
+            final String customerId,
+            final String tokenId) throws ApiException, IOException;
+
+    /**
+     * Updates the metadata a customer.
+     * @param  customerId  Required parameter: The customer id
+     * @param  request  Required parameter: Request for updating the customer metadata
      * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetCustomerResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetCustomerResponse updateCustomerMetadata(
+            final String customerId,
+            final UpdateMetadataRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Get a customer's card.
+     * @param  customerId  Required parameter: Customer id
+     * @param  cardId  Required parameter: Card id
      * @return    Returns the GetCardResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetCardResponse createCard(
+    GetCardResponse getCard(
             final String customerId,
-            final CreateCardRequest request,
+            final String cardId) throws ApiException, IOException;
+
+    /**
+     * Delete a Customer's access tokens.
+     * @param  customerId  Required parameter: Customer Id
+     * @return    Returns the ListAccessTokensResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListAccessTokensResponse deleteAccessTokens(
+            final String customerId) throws ApiException, IOException;
+
+    /**
+     * Creates a access token for a customer.
+     * @param  customerId  Required parameter: Customer Id
+     * @param  request  Required parameter: Request for creating a access token
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetAccessTokenResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetAccessTokenResponse createAccessToken(
+            final String customerId,
+            final CreateAccessTokenRequest request,
             final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Get all access tokens from a customer.
+     * @param  customerId  Required parameter: Customer Id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @return    Returns the ListAccessTokensResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListAccessTokensResponse getAccessTokens(
+            final String customerId,
+            final Integer page,
+            final Integer size) throws ApiException, IOException;
 
     /**
      * Get all Customers.
@@ -184,88 +278,6 @@ public interface CustomersController {
     GetCustomerResponse updateCustomer(
             final String customerId,
             final UpdateCustomerRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Creates a access token for a customer.
-     * @param  customerId  Required parameter: Customer Id
-     * @param  request  Required parameter: Request for creating a access token
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetAccessTokenResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetAccessTokenResponse createAccessToken(
-            final String customerId,
-            final CreateAccessTokenRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Get all access tokens from a customer.
-     * @param  customerId  Required parameter: Customer Id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @return    Returns the ListAccessTokensResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    ListAccessTokensResponse getAccessTokens(
-            final String customerId,
-            final Integer page,
-            final Integer size) throws ApiException, IOException;
-
-    /**
-     * Get all cards from a customer.
-     * @param  customerId  Required parameter: Customer Id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @return    Returns the ListCardsResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    ListCardsResponse getCards(
-            final String customerId,
-            final Integer page,
-            final Integer size) throws ApiException, IOException;
-
-    /**
-     * Renew a card.
-     * @param  customerId  Required parameter: Customer id
-     * @param  cardId  Required parameter: Card Id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetCardResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetCardResponse renewCard(
-            final String customerId,
-            final String cardId,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Get a Customer's access token.
-     * @param  customerId  Required parameter: Customer Id
-     * @param  tokenId  Required parameter: Token Id
-     * @return    Returns the GetAccessTokenResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetAccessTokenResponse getAccessToken(
-            final String customerId,
-            final String tokenId) throws ApiException, IOException;
-
-    /**
-     * Updates the metadata a customer.
-     * @param  customerId  Required parameter: The customer id
-     * @param  request  Required parameter: Request for updating the customer metadata
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetCustomerResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetCustomerResponse updateCustomerMetadata(
-            final String customerId,
-            final UpdateMetadataRequest request,
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
@@ -305,17 +317,5 @@ public interface CustomersController {
      */
     GetCustomerResponse getCustomer(
             final String customerId) throws ApiException, IOException;
-
-    /**
-     * Get a customer's card.
-     * @param  customerId  Required parameter: Customer id
-     * @param  cardId  Required parameter: Card id
-     * @return    Returns the GetCardResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetCardResponse getCard(
-            final String customerId,
-            final String cardId) throws ApiException, IOException;
 
 }

--- a/src/main/java/me/pagar/api/controllers/DefaultChargesController.java
+++ b/src/main/java/me/pagar/api/controllers/DefaultChargesController.java
@@ -208,6 +208,222 @@ public final class DefaultChargesController extends BaseController implements Ch
     }
 
     /**
+     * Updates the card from a charge.
+     * @param  chargeId  Required parameter: Charge id
+     * @param  request  Required parameter: Request for updating a charge's card
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetChargeResponse updateChargeCard(
+            final String chargeId,
+            final UpdateChargeCardRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateChargeCardRequest(chargeId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateChargeCardResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateChargeCard.
+     */
+    private HttpRequest buildUpdateChargeCardRequest(
+            final String chargeId,
+            final UpdateChargeCardRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/charges/{charge_id}/card");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("charge_id",
+                new SimpleEntry<Object, Boolean>(chargeId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateChargeCard.
+     * @return An object of type GetChargeResponse
+     */
+    private GetChargeResponse handleUpdateChargeCardResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetChargeResponse result = ApiHelper.deserialize(responseBody,
+                GetChargeResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  status  Required parameter: Example:
+     * @param  createdSince  Optional parameter: Example:
+     * @param  createdUntil  Optional parameter: Example:
+     * @return    Returns the GetChargesSummaryResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetChargesSummaryResponse getChargesSummary(
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) throws ApiException, IOException {
+        HttpRequest request = buildGetChargesSummaryRequest(status, createdSince, createdUntil);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetChargesSummaryResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getChargesSummary.
+     */
+    private HttpRequest buildGetChargesSummaryRequest(
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/charges/summary");
+
+        //load all query parameters
+        Map<String, Object> queryParameters = new HashMap<>();
+        queryParameters.put("status", status);
+        queryParameters.put("created_since", DateTimeHelper.toRfc8601DateTime(createdSince));
+        queryParameters.put("created_until", DateTimeHelper.toRfc8601DateTime(createdUntil));
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
+                null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getChargesSummary.
+     * @return An object of type GetChargesSummaryResponse
+     */
+    private GetChargesSummaryResponse handleGetChargesSummaryResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetChargesSummaryResponse result = ApiHelper.deserialize(responseBody,
+                GetChargesSummaryResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a new charge.
+     * @param  request  Required parameter: Request for creating a charge
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetChargeResponse createCharge(
+            final CreateChargeRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreateChargeRequest(request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCreateChargeResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createCharge.
+     */
+    private HttpRequest buildCreateChargeRequest(
+            final CreateChargeRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/Charges");
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for createCharge.
+     * @return An object of type GetChargeResponse
+     */
+    private GetChargeResponse handleCreateChargeResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetChargeResponse result = ApiHelper.deserialize(responseBody,
+                GetChargeResponse.class);
+
+        return result;
+    }
+
+    /**
      * @param  chargeId  Required parameter: Charge Id
      * @param  page  Optional parameter: Page number
      * @param  size  Optional parameter: Page size
@@ -285,41 +501,40 @@ public final class DefaultChargesController extends BaseController implements Ch
     }
 
     /**
-     * Updates the due date from a charge.
-     * @param  chargeId  Required parameter: Charge Id
-     * @param  request  Required parameter: Request for updating the due date
+     * Captures a charge.
+     * @param  chargeId  Required parameter: Charge id
+     * @param  request  Optional parameter: Request for capturing a charge
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetChargeResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetChargeResponse updateChargeDueDate(
+    public GetChargeResponse captureCharge(
             final String chargeId,
-            final UpdateChargeDueDateRequest request,
+            final CreateCaptureChargeRequest request,
             final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateChargeDueDateRequest(chargeId, request,
-                idempotencyKey);
+        HttpRequest internalRequest = buildCaptureChargeRequest(chargeId, request, idempotencyKey);
         authManagers.get("global").apply(internalRequest);
 
         HttpResponse response = getClientInstance().execute(internalRequest, false);
         HttpContext context = new HttpContext(internalRequest, response);
 
-        return handleUpdateChargeDueDateResponse(context);
+        return handleCaptureChargeResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for updateChargeDueDate.
+     * Builds the HttpRequest object for captureCharge.
      */
-    private HttpRequest buildUpdateChargeDueDateRequest(
+    private HttpRequest buildCaptureChargeRequest(
             final String chargeId,
-            final UpdateChargeDueDateRequest request,
+            final CreateCaptureChargeRequest request,
             final String idempotencyKey) throws JsonProcessingException {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/Charges/{charge_id}/due-date");
+                + "/charges/{charge_id}/capture");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
@@ -336,17 +551,159 @@ public final class DefaultChargesController extends BaseController implements Ch
 
         //prepare and invoke the API call request to fetch the response
         String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
                 bodyJson);
 
         return internalRequest;
     }
 
     /**
-     * Processes the response for updateChargeDueDate.
+     * Processes the response for captureCharge.
      * @return An object of type GetChargeResponse
      */
-    private GetChargeResponse handleUpdateChargeDueDateResponse(
+    private GetChargeResponse handleCaptureChargeResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetChargeResponse result = ApiHelper.deserialize(responseBody,
+                GetChargeResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Get a charge from its id.
+     * @param  chargeId  Required parameter: Charge id
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetChargeResponse getCharge(
+            final String chargeId) throws ApiException, IOException {
+        HttpRequest request = buildGetChargeRequest(chargeId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetChargeResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getCharge.
+     */
+    private HttpRequest buildGetChargeRequest(
+            final String chargeId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/charges/{charge_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("charge_id",
+                new SimpleEntry<Object, Boolean>(chargeId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getCharge.
+     * @return An object of type GetChargeResponse
+     */
+    private GetChargeResponse handleGetChargeResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetChargeResponse result = ApiHelper.deserialize(responseBody,
+                GetChargeResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Cancel a charge.
+     * @param  chargeId  Required parameter: Charge id
+     * @param  request  Optional parameter: Request for cancelling a charge
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetChargeResponse cancelCharge(
+            final String chargeId,
+            final CreateCancelChargeRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCancelChargeRequest(chargeId, request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCancelChargeResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for cancelCharge.
+     */
+    private HttpRequest buildCancelChargeRequest(
+            final String chargeId,
+            final CreateCancelChargeRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/charges/{charge_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("charge_id",
+                new SimpleEntry<Object, Boolean>(chargeId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().deleteBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for cancelCharge.
+     * @return An object of type GetChargeResponse
+     */
+    private GetChargeResponse handleCancelChargeResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -462,510 +819,6 @@ public final class DefaultChargesController extends BaseController implements Ch
     }
 
     /**
-     * Captures a charge.
-     * @param  chargeId  Required parameter: Charge id
-     * @param  request  Optional parameter: Request for capturing a charge
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetChargeResponse captureCharge(
-            final String chargeId,
-            final CreateCaptureChargeRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCaptureChargeRequest(chargeId, request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCaptureChargeResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for captureCharge.
-     */
-    private HttpRequest buildCaptureChargeRequest(
-            final String chargeId,
-            final CreateCaptureChargeRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/charges/{charge_id}/capture");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("charge_id",
-                new SimpleEntry<Object, Boolean>(chargeId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for captureCharge.
-     * @return An object of type GetChargeResponse
-     */
-    private GetChargeResponse handleCaptureChargeResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetChargeResponse result = ApiHelper.deserialize(responseBody,
-                GetChargeResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Updates the card from a charge.
-     * @param  chargeId  Required parameter: Charge id
-     * @param  request  Required parameter: Request for updating a charge's card
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetChargeResponse updateChargeCard(
-            final String chargeId,
-            final UpdateChargeCardRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateChargeCardRequest(chargeId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateChargeCardResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateChargeCard.
-     */
-    private HttpRequest buildUpdateChargeCardRequest(
-            final String chargeId,
-            final UpdateChargeCardRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/charges/{charge_id}/card");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("charge_id",
-                new SimpleEntry<Object, Boolean>(chargeId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateChargeCard.
-     * @return An object of type GetChargeResponse
-     */
-    private GetChargeResponse handleUpdateChargeCardResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetChargeResponse result = ApiHelper.deserialize(responseBody,
-                GetChargeResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Get a charge from its id.
-     * @param  chargeId  Required parameter: Charge id
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetChargeResponse getCharge(
-            final String chargeId) throws ApiException, IOException {
-        HttpRequest request = buildGetChargeRequest(chargeId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetChargeResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getCharge.
-     */
-    private HttpRequest buildGetChargeRequest(
-            final String chargeId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/charges/{charge_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("charge_id",
-                new SimpleEntry<Object, Boolean>(chargeId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getCharge.
-     * @return An object of type GetChargeResponse
-     */
-    private GetChargeResponse handleGetChargeResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetChargeResponse result = ApiHelper.deserialize(responseBody,
-                GetChargeResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  status  Required parameter: Example:
-     * @param  createdSince  Optional parameter: Example:
-     * @param  createdUntil  Optional parameter: Example:
-     * @return    Returns the GetChargesSummaryResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetChargesSummaryResponse getChargesSummary(
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) throws ApiException, IOException {
-        HttpRequest request = buildGetChargesSummaryRequest(status, createdSince, createdUntil);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetChargesSummaryResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getChargesSummary.
-     */
-    private HttpRequest buildGetChargesSummaryRequest(
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/charges/summary");
-
-        //load all query parameters
-        Map<String, Object> queryParameters = new HashMap<>();
-        queryParameters.put("status", status);
-        queryParameters.put("created_since", DateTimeHelper.toRfc8601DateTime(createdSince));
-        queryParameters.put("created_until", DateTimeHelper.toRfc8601DateTime(createdUntil));
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
-                null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getChargesSummary.
-     * @return An object of type GetChargesSummaryResponse
-     */
-    private GetChargesSummaryResponse handleGetChargesSummaryResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetChargesSummaryResponse result = ApiHelper.deserialize(responseBody,
-                GetChargesSummaryResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Retries a charge.
-     * @param  chargeId  Required parameter: Charge id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetChargeResponse retryCharge(
-            final String chargeId,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildRetryChargeRequest(chargeId, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleRetryChargeResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for retryCharge.
-     */
-    private HttpRequest buildRetryChargeRequest(
-            final String chargeId,
-            final String idempotencyKey) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/charges/{charge_id}/retry");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("charge_id",
-                new SimpleEntry<Object, Boolean>(chargeId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().post(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for retryCharge.
-     * @return An object of type GetChargeResponse
-     */
-    private GetChargeResponse handleRetryChargeResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetChargeResponse result = ApiHelper.deserialize(responseBody,
-                GetChargeResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Cancel a charge.
-     * @param  chargeId  Required parameter: Charge id
-     * @param  request  Optional parameter: Request for cancelling a charge
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetChargeResponse cancelCharge(
-            final String chargeId,
-            final CreateCancelChargeRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCancelChargeRequest(chargeId, request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCancelChargeResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for cancelCharge.
-     */
-    private HttpRequest buildCancelChargeRequest(
-            final String chargeId,
-            final CreateCancelChargeRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/charges/{charge_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("charge_id",
-                new SimpleEntry<Object, Boolean>(chargeId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().deleteBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for cancelCharge.
-     * @return An object of type GetChargeResponse
-     */
-    private GetChargeResponse handleCancelChargeResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetChargeResponse result = ApiHelper.deserialize(responseBody,
-                GetChargeResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Creates a new charge.
-     * @param  request  Required parameter: Request for creating a charge
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetChargeResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetChargeResponse createCharge(
-            final CreateChargeRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreateChargeRequest(request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCreateChargeResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createCharge.
-     */
-    private HttpRequest buildCreateChargeRequest(
-            final CreateChargeRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/Charges");
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for createCharge.
-     * @return An object of type GetChargeResponse
-     */
-    private GetChargeResponse handleCreateChargeResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetChargeResponse result = ApiHelper.deserialize(responseBody,
-                GetChargeResponse.class);
-
-        return result;
-    }
-
-    /**
      * @param  chargeId  Required parameter: Example:
      * @param  request  Optional parameter: Request for confirm payment
      * @param  idempotencyKey  Optional parameter: Example:
@@ -1026,6 +879,153 @@ public final class DefaultChargesController extends BaseController implements Ch
      * @return An object of type GetChargeResponse
      */
     private GetChargeResponse handleConfirmPaymentResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetChargeResponse result = ApiHelper.deserialize(responseBody,
+                GetChargeResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Updates the due date from a charge.
+     * @param  chargeId  Required parameter: Charge Id
+     * @param  request  Required parameter: Request for updating the due date
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetChargeResponse updateChargeDueDate(
+            final String chargeId,
+            final UpdateChargeDueDateRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateChargeDueDateRequest(chargeId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateChargeDueDateResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateChargeDueDate.
+     */
+    private HttpRequest buildUpdateChargeDueDateRequest(
+            final String chargeId,
+            final UpdateChargeDueDateRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/Charges/{charge_id}/due-date");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("charge_id",
+                new SimpleEntry<Object, Boolean>(chargeId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateChargeDueDate.
+     * @return An object of type GetChargeResponse
+     */
+    private GetChargeResponse handleUpdateChargeDueDateResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetChargeResponse result = ApiHelper.deserialize(responseBody,
+                GetChargeResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Retries a charge.
+     * @param  chargeId  Required parameter: Charge id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetChargeResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetChargeResponse retryCharge(
+            final String chargeId,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildRetryChargeRequest(chargeId, idempotencyKey);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleRetryChargeResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for retryCharge.
+     */
+    private HttpRequest buildRetryChargeRequest(
+            final String chargeId,
+            final String idempotencyKey) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/charges/{charge_id}/retry");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("charge_id",
+                new SimpleEntry<Object, Boolean>(chargeId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().post(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for retryCharge.
+     * @return An object of type GetChargeResponse
+     */
+    private GetChargeResponse handleRetryChargeResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 

--- a/src/main/java/me/pagar/api/controllers/DefaultCustomersController.java
+++ b/src/main/java/me/pagar/api/controllers/DefaultCustomersController.java
@@ -295,73 +295,6 @@ public final class DefaultCustomersController extends BaseController implements 
     }
 
     /**
-     * Creates a new customer.
-     * @param  request  Required parameter: Request for creating a customer
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetCustomerResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetCustomerResponse createCustomer(
-            final CreateCustomerRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreateCustomerRequest(request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCreateCustomerResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createCustomer.
-     */
-    private HttpRequest buildCreateCustomerRequest(
-            final CreateCustomerRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers");
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for createCustomer.
-     * @return An object of type GetCustomerResponse
-     */
-    private GetCustomerResponse handleCreateCustomerResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetCustomerResponse result = ApiHelper.deserialize(responseBody,
-                GetCustomerResponse.class);
-
-        return result;
-    }
-
-    /**
      * Creates a new address for a customer.
      * @param  customerId  Required parameter: Customer Id
      * @param  request  Required parameter: Request for creating an address
@@ -439,34 +372,107 @@ public final class DefaultCustomersController extends BaseController implements 
     }
 
     /**
-     * Delete a Customer's access tokens.
-     * @param  customerId  Required parameter: Customer Id
-     * @return    Returns the ListAccessTokensResponse response from the API call
+     * Creates a new customer.
+     * @param  request  Required parameter: Request for creating a customer
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetCustomerResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public ListAccessTokensResponse deleteAccessTokens(
-            final String customerId) throws ApiException, IOException {
-        HttpRequest request = buildDeleteAccessTokensRequest(customerId);
-        authManagers.get("global").apply(request);
+    public GetCustomerResponse createCustomer(
+            final CreateCustomerRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreateCustomerRequest(request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
 
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
 
-        return handleDeleteAccessTokensResponse(context);
+        return handleCreateCustomerResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for deleteAccessTokens.
+     * Builds the HttpRequest object for createCustomer.
      */
-    private HttpRequest buildDeleteAccessTokensRequest(
-            final String customerId) {
+    private HttpRequest buildCreateCustomerRequest(
+            final CreateCustomerRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers/{customer_id}/access-tokens/");
+                + "/customers");
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for createCustomer.
+     * @return An object of type GetCustomerResponse
+     */
+    private GetCustomerResponse handleCreateCustomerResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetCustomerResponse result = ApiHelper.deserialize(responseBody,
+                GetCustomerResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a new card for a customer.
+     * @param  customerId  Required parameter: Customer id
+     * @param  request  Required parameter: Request for creating a card
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetCardResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetCardResponse createCard(
+            final String customerId,
+            final CreateCardRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreateCardRequest(customerId, request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCreateCardResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createCard.
+     */
+    private HttpRequest buildCreateCardRequest(
+            final String customerId,
+            final CreateCardRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/customers/{customer_id}/cards");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
@@ -476,20 +482,24 @@ public final class DefaultCustomersController extends BaseController implements 
 
         //load all headers for the outgoing API request
         Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
         headers.add("user-agent", BaseController.userAgent);
         headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
 
         //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+                bodyJson);
 
-        return request;
+        return internalRequest;
     }
 
     /**
-     * Processes the response for deleteAccessTokens.
-     * @return An object of type ListAccessTokensResponse
+     * Processes the response for createCard.
+     * @return An object of type GetCardResponse
      */
-    private ListAccessTokensResponse handleDeleteAccessTokensResponse(
+    private GetCardResponse handleCreateCardResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -498,8 +508,161 @@ public final class DefaultCustomersController extends BaseController implements 
 
         //extract result from the http response
         String responseBody = ((HttpStringResponse) response).getBody();
-        ListAccessTokensResponse result = ApiHelper.deserialize(responseBody,
-                ListAccessTokensResponse.class);
+        GetCardResponse result = ApiHelper.deserialize(responseBody,
+                GetCardResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Get all cards from a customer.
+     * @param  customerId  Required parameter: Customer Id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @return    Returns the ListCardsResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public ListCardsResponse getCards(
+            final String customerId,
+            final Integer page,
+            final Integer size) throws ApiException, IOException {
+        HttpRequest request = buildGetCardsRequest(customerId, page, size);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetCardsResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getCards.
+     */
+    private HttpRequest buildGetCardsRequest(
+            final String customerId,
+            final Integer page,
+            final Integer size) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/customers/{customer_id}/cards");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("customer_id",
+                new SimpleEntry<Object, Boolean>(customerId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all query parameters
+        Map<String, Object> queryParameters = new HashMap<>();
+        queryParameters.put("page", page);
+        queryParameters.put("size", size);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
+                null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getCards.
+     * @return An object of type ListCardsResponse
+     */
+    private ListCardsResponse handleGetCardsResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        ListCardsResponse result = ApiHelper.deserialize(responseBody,
+                ListCardsResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Renew a card.
+     * @param  customerId  Required parameter: Customer id
+     * @param  cardId  Required parameter: Card Id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetCardResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetCardResponse renewCard(
+            final String customerId,
+            final String cardId,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildRenewCardRequest(customerId, cardId, idempotencyKey);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleRenewCardResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for renewCard.
+     */
+    private HttpRequest buildRenewCardRequest(
+            final String customerId,
+            final String cardId,
+            final String idempotencyKey) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/customers/{customer_id}/cards/{card_id}/renew");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("customer_id",
+                new SimpleEntry<Object, Boolean>(customerId, true));
+        templateParameters.put("card_id",
+                new SimpleEntry<Object, Boolean>(cardId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().post(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for renewCard.
+     * @return An object of type GetCardResponse
+     */
+    private GetCardResponse handleRenewCardResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetCardResponse result = ApiHelper.deserialize(responseBody,
+                GetCardResponse.class);
 
         return result;
     }
@@ -651,40 +814,112 @@ public final class DefaultCustomersController extends BaseController implements 
     }
 
     /**
-     * Creates a new card for a customer.
-     * @param  customerId  Required parameter: Customer id
-     * @param  request  Required parameter: Request for creating a card
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetCardResponse response from the API call
+     * Get a Customer's access token.
+     * @param  customerId  Required parameter: Customer Id
+     * @param  tokenId  Required parameter: Token Id
+     * @return    Returns the GetAccessTokenResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetCardResponse createCard(
+    public GetAccessTokenResponse getAccessToken(
             final String customerId,
-            final CreateCardRequest request,
+            final String tokenId) throws ApiException, IOException {
+        HttpRequest request = buildGetAccessTokenRequest(customerId, tokenId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetAccessTokenResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getAccessToken.
+     */
+    private HttpRequest buildGetAccessTokenRequest(
+            final String customerId,
+            final String tokenId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/customers/{customer_id}/access-tokens/{token_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("customer_id",
+                new SimpleEntry<Object, Boolean>(customerId, true));
+        templateParameters.put("token_id",
+                new SimpleEntry<Object, Boolean>(tokenId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getAccessToken.
+     * @return An object of type GetAccessTokenResponse
+     */
+    private GetAccessTokenResponse handleGetAccessTokenResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetAccessTokenResponse result = ApiHelper.deserialize(responseBody,
+                GetAccessTokenResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Updates the metadata a customer.
+     * @param  customerId  Required parameter: The customer id
+     * @param  request  Required parameter: Request for updating the customer metadata
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetCustomerResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetCustomerResponse updateCustomerMetadata(
+            final String customerId,
+            final UpdateMetadataRequest request,
             final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreateCardRequest(customerId, request, idempotencyKey);
+        HttpRequest internalRequest = buildUpdateCustomerMetadataRequest(customerId, request,
+                idempotencyKey);
         authManagers.get("global").apply(internalRequest);
 
         HttpResponse response = getClientInstance().execute(internalRequest, false);
         HttpContext context = new HttpContext(internalRequest, response);
 
-        return handleCreateCardResponse(context);
+        return handleUpdateCustomerMetadataResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for createCard.
+     * Builds the HttpRequest object for updateCustomerMetadata.
      */
-    private HttpRequest buildCreateCardRequest(
+    private HttpRequest buildUpdateCustomerMetadataRequest(
             final String customerId,
-            final CreateCardRequest request,
+            final UpdateMetadataRequest request,
             final String idempotencyKey) throws JsonProcessingException {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers/{customer_id}/cards");
+                + "/Customers/{customer_id}/metadata");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
@@ -701,17 +936,88 @@ public final class DefaultCustomersController extends BaseController implements 
 
         //prepare and invoke the API call request to fetch the response
         String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
                 bodyJson);
 
         return internalRequest;
     }
 
     /**
-     * Processes the response for createCard.
+     * Processes the response for updateCustomerMetadata.
+     * @return An object of type GetCustomerResponse
+     */
+    private GetCustomerResponse handleUpdateCustomerMetadataResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetCustomerResponse result = ApiHelper.deserialize(responseBody,
+                GetCustomerResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Get a customer's card.
+     * @param  customerId  Required parameter: Customer id
+     * @param  cardId  Required parameter: Card id
+     * @return    Returns the GetCardResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetCardResponse getCard(
+            final String customerId,
+            final String cardId) throws ApiException, IOException {
+        HttpRequest request = buildGetCardRequest(customerId, cardId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetCardResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getCard.
+     */
+    private HttpRequest buildGetCardRequest(
+            final String customerId,
+            final String cardId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/customers/{customer_id}/cards/{card_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("customer_id",
+                new SimpleEntry<Object, Boolean>(customerId, true));
+        templateParameters.put("card_id",
+                new SimpleEntry<Object, Boolean>(cardId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getCard.
      * @return An object of type GetCardResponse
      */
-    private GetCardResponse handleCreateCardResponse(
+    private GetCardResponse handleGetCardResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -727,128 +1033,34 @@ public final class DefaultCustomersController extends BaseController implements 
     }
 
     /**
-     * Get all Customers.
-     * @param  name  Optional parameter: Name of the Customer
-     * @param  document  Optional parameter: Document of the Customer
-     * @param  page  Optional parameter: Current page the the search
-     * @param  size  Optional parameter: Quantity pages of the search
-     * @param  email  Optional parameter: Customer's email
-     * @param  code  Optional parameter: Customer's code
-     * @return    Returns the ListCustomersResponse response from the API call
+     * Delete a Customer's access tokens.
+     * @param  customerId  Required parameter: Customer Id
+     * @return    Returns the ListAccessTokensResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public ListCustomersResponse getCustomers(
-            final String name,
-            final String document,
-            final Integer page,
-            final Integer size,
-            final String email,
-            final String code) throws ApiException, IOException {
-        HttpRequest request = buildGetCustomersRequest(name, document, page, size, email, code);
+    public ListAccessTokensResponse deleteAccessTokens(
+            final String customerId) throws ApiException, IOException {
+        HttpRequest request = buildDeleteAccessTokensRequest(customerId);
         authManagers.get("global").apply(request);
 
         HttpResponse response = getClientInstance().execute(request, false);
         HttpContext context = new HttpContext(request, response);
 
-        return handleGetCustomersResponse(context);
+        return handleDeleteAccessTokensResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for getCustomers.
+     * Builds the HttpRequest object for deleteAccessTokens.
      */
-    private HttpRequest buildGetCustomersRequest(
-            final String name,
-            final String document,
-            final Integer page,
-            final Integer size,
-            final String email,
-            final String code) {
+    private HttpRequest buildDeleteAccessTokensRequest(
+            final String customerId) {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers");
-
-        //load all query parameters
-        Map<String, Object> queryParameters = new HashMap<>();
-        queryParameters.put("name", name);
-        queryParameters.put("document", document);
-        queryParameters.put("page",
-                (page != null) ? page : 1);
-        queryParameters.put("size",
-                (size != null) ? size : 10);
-        queryParameters.put("email", email);
-        queryParameters.put("Code", code);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
-                null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getCustomers.
-     * @return An object of type ListCustomersResponse
-     */
-    private ListCustomersResponse handleGetCustomersResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        ListCustomersResponse result = ApiHelper.deserialize(responseBody,
-                ListCustomersResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Updates a customer.
-     * @param  customerId  Required parameter: Customer id
-     * @param  request  Required parameter: Request for updating a customer
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetCustomerResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetCustomerResponse updateCustomer(
-            final String customerId,
-            final UpdateCustomerRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateCustomerRequest(customerId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateCustomerResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateCustomer.
-     */
-    private HttpRequest buildUpdateCustomerRequest(
-            final String customerId,
-            final UpdateCustomerRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers/{customer_id}");
+                + "/customers/{customer_id}/access-tokens/");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
@@ -858,24 +1070,20 @@ public final class DefaultCustomersController extends BaseController implements 
 
         //load all headers for the outgoing API request
         Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
         headers.add("user-agent", BaseController.userAgent);
         headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
 
         //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().putBody(queryBuilder, headers, null,
-                bodyJson);
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
 
-        return internalRequest;
+        return request;
     }
 
     /**
-     * Processes the response for updateCustomer.
-     * @return An object of type GetCustomerResponse
+     * Processes the response for deleteAccessTokens.
+     * @return An object of type ListAccessTokensResponse
      */
-    private GetCustomerResponse handleUpdateCustomerResponse(
+    private ListAccessTokensResponse handleDeleteAccessTokensResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -884,8 +1092,8 @@ public final class DefaultCustomersController extends BaseController implements 
 
         //extract result from the http response
         String responseBody = ((HttpStringResponse) response).getBody();
-        GetCustomerResponse result = ApiHelper.deserialize(responseBody,
-                GetCustomerResponse.class);
+        ListAccessTokensResponse result = ApiHelper.deserialize(responseBody,
+                ListAccessTokensResponse.class);
 
         return result;
     }
@@ -1046,51 +1254,60 @@ public final class DefaultCustomersController extends BaseController implements 
     }
 
     /**
-     * Get all cards from a customer.
-     * @param  customerId  Required parameter: Customer Id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @return    Returns the ListCardsResponse response from the API call
+     * Get all Customers.
+     * @param  name  Optional parameter: Name of the Customer
+     * @param  document  Optional parameter: Document of the Customer
+     * @param  page  Optional parameter: Current page the the search
+     * @param  size  Optional parameter: Quantity pages of the search
+     * @param  email  Optional parameter: Customer's email
+     * @param  code  Optional parameter: Customer's code
+     * @return    Returns the ListCustomersResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public ListCardsResponse getCards(
-            final String customerId,
+    public ListCustomersResponse getCustomers(
+            final String name,
+            final String document,
             final Integer page,
-            final Integer size) throws ApiException, IOException {
-        HttpRequest request = buildGetCardsRequest(customerId, page, size);
+            final Integer size,
+            final String email,
+            final String code) throws ApiException, IOException {
+        HttpRequest request = buildGetCustomersRequest(name, document, page, size, email, code);
         authManagers.get("global").apply(request);
 
         HttpResponse response = getClientInstance().execute(request, false);
         HttpContext context = new HttpContext(request, response);
 
-        return handleGetCardsResponse(context);
+        return handleGetCustomersResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for getCards.
+     * Builds the HttpRequest object for getCustomers.
      */
-    private HttpRequest buildGetCardsRequest(
-            final String customerId,
+    private HttpRequest buildGetCustomersRequest(
+            final String name,
+            final String document,
             final Integer page,
-            final Integer size) {
+            final Integer size,
+            final String email,
+            final String code) {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers/{customer_id}/cards");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("customer_id",
-                new SimpleEntry<Object, Boolean>(customerId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+                + "/customers");
 
         //load all query parameters
         Map<String, Object> queryParameters = new HashMap<>();
-        queryParameters.put("page", page);
-        queryParameters.put("size", size);
+        queryParameters.put("name", name);
+        queryParameters.put("document", document);
+        queryParameters.put("page",
+                (page != null) ? page : 1);
+        queryParameters.put("size",
+                (size != null) ? size : 10);
+        queryParameters.put("email", email);
+        queryParameters.put("Code", code);
 
         //load all headers for the outgoing API request
         Headers headers = new Headers();
@@ -1105,10 +1322,10 @@ public final class DefaultCustomersController extends BaseController implements 
     }
 
     /**
-     * Processes the response for getCards.
-     * @return An object of type ListCardsResponse
+     * Processes the response for getCustomers.
+     * @return An object of type ListCustomersResponse
      */
-    private ListCardsResponse handleGetCardsResponse(
+    private ListCustomersResponse handleGetCustomersResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -1117,194 +1334,48 @@ public final class DefaultCustomersController extends BaseController implements 
 
         //extract result from the http response
         String responseBody = ((HttpStringResponse) response).getBody();
-        ListCardsResponse result = ApiHelper.deserialize(responseBody,
-                ListCardsResponse.class);
+        ListCustomersResponse result = ApiHelper.deserialize(responseBody,
+                ListCustomersResponse.class);
 
         return result;
     }
 
     /**
-     * Renew a card.
+     * Updates a customer.
      * @param  customerId  Required parameter: Customer id
-     * @param  cardId  Required parameter: Card Id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetCardResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetCardResponse renewCard(
-            final String customerId,
-            final String cardId,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildRenewCardRequest(customerId, cardId, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleRenewCardResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for renewCard.
-     */
-    private HttpRequest buildRenewCardRequest(
-            final String customerId,
-            final String cardId,
-            final String idempotencyKey) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers/{customer_id}/cards/{card_id}/renew");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("customer_id",
-                new SimpleEntry<Object, Boolean>(customerId, true));
-        templateParameters.put("card_id",
-                new SimpleEntry<Object, Boolean>(cardId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().post(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for renewCard.
-     * @return An object of type GetCardResponse
-     */
-    private GetCardResponse handleRenewCardResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetCardResponse result = ApiHelper.deserialize(responseBody,
-                GetCardResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Get a Customer's access token.
-     * @param  customerId  Required parameter: Customer Id
-     * @param  tokenId  Required parameter: Token Id
-     * @return    Returns the GetAccessTokenResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetAccessTokenResponse getAccessToken(
-            final String customerId,
-            final String tokenId) throws ApiException, IOException {
-        HttpRequest request = buildGetAccessTokenRequest(customerId, tokenId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetAccessTokenResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getAccessToken.
-     */
-    private HttpRequest buildGetAccessTokenRequest(
-            final String customerId,
-            final String tokenId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers/{customer_id}/access-tokens/{token_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("customer_id",
-                new SimpleEntry<Object, Boolean>(customerId, true));
-        templateParameters.put("token_id",
-                new SimpleEntry<Object, Boolean>(tokenId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getAccessToken.
-     * @return An object of type GetAccessTokenResponse
-     */
-    private GetAccessTokenResponse handleGetAccessTokenResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetAccessTokenResponse result = ApiHelper.deserialize(responseBody,
-                GetAccessTokenResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Updates the metadata a customer.
-     * @param  customerId  Required parameter: The customer id
-     * @param  request  Required parameter: Request for updating the customer metadata
+     * @param  request  Required parameter: Request for updating a customer
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetCustomerResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetCustomerResponse updateCustomerMetadata(
+    public GetCustomerResponse updateCustomer(
             final String customerId,
-            final UpdateMetadataRequest request,
+            final UpdateCustomerRequest request,
             final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateCustomerMetadataRequest(customerId, request,
+        HttpRequest internalRequest = buildUpdateCustomerRequest(customerId, request,
                 idempotencyKey);
         authManagers.get("global").apply(internalRequest);
 
         HttpResponse response = getClientInstance().execute(internalRequest, false);
         HttpContext context = new HttpContext(internalRequest, response);
 
-        return handleUpdateCustomerMetadataResponse(context);
+        return handleUpdateCustomerResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for updateCustomerMetadata.
+     * Builds the HttpRequest object for updateCustomer.
      */
-    private HttpRequest buildUpdateCustomerMetadataRequest(
+    private HttpRequest buildUpdateCustomerRequest(
             final String customerId,
-            final UpdateMetadataRequest request,
+            final UpdateCustomerRequest request,
             final String idempotencyKey) throws JsonProcessingException {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/Customers/{customer_id}/metadata");
+                + "/customers/{customer_id}");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
@@ -1321,17 +1392,17 @@ public final class DefaultCustomersController extends BaseController implements 
 
         //prepare and invoke the API call request to fetch the response
         String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+        HttpRequest internalRequest = getClientInstance().putBody(queryBuilder, headers, null,
                 bodyJson);
 
         return internalRequest;
     }
 
     /**
-     * Processes the response for updateCustomerMetadata.
+     * Processes the response for updateCustomer.
      * @return An object of type GetCustomerResponse
      */
-    private GetCustomerResponse handleUpdateCustomerMetadataResponse(
+    private GetCustomerResponse handleUpdateCustomerResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -1561,77 +1632,6 @@ public final class DefaultCustomersController extends BaseController implements 
         String responseBody = ((HttpStringResponse) response).getBody();
         GetCustomerResponse result = ApiHelper.deserialize(responseBody,
                 GetCustomerResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Get a customer's card.
-     * @param  customerId  Required parameter: Customer id
-     * @param  cardId  Required parameter: Card id
-     * @return    Returns the GetCardResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetCardResponse getCard(
-            final String customerId,
-            final String cardId) throws ApiException, IOException {
-        HttpRequest request = buildGetCardRequest(customerId, cardId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetCardResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getCard.
-     */
-    private HttpRequest buildGetCardRequest(
-            final String customerId,
-            final String cardId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/customers/{customer_id}/cards/{card_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("customer_id",
-                new SimpleEntry<Object, Boolean>(customerId, true));
-        templateParameters.put("card_id",
-                new SimpleEntry<Object, Boolean>(cardId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getCard.
-     * @return An object of type GetCardResponse
-     */
-    private GetCardResponse handleGetCardResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetCardResponse result = ApiHelper.deserialize(responseBody,
-                GetCardResponse.class);
 
         return result;
     }

--- a/src/main/java/me/pagar/api/controllers/DefaultInvoicesController.java
+++ b/src/main/java/me/pagar/api/controllers/DefaultInvoicesController.java
@@ -47,218 +47,6 @@ public final class DefaultInvoicesController extends BaseController implements I
 
 
     /**
-     * Updates the metadata from an invoice.
-     * @param  invoiceId  Required parameter: The invoice id
-     * @param  request  Required parameter: Request for updating the invoice metadata
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetInvoiceResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetInvoiceResponse updateInvoiceMetadata(
-            final String invoiceId,
-            final UpdateMetadataRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateInvoiceMetadataRequest(invoiceId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateInvoiceMetadataResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateInvoiceMetadata.
-     */
-    private HttpRequest buildUpdateInvoiceMetadataRequest(
-            final String invoiceId,
-            final UpdateMetadataRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/invoices/{invoice_id}/metadata");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("invoice_id",
-                new SimpleEntry<Object, Boolean>(invoiceId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateInvoiceMetadata.
-     * @return An object of type GetInvoiceResponse
-     */
-    private GetInvoiceResponse handleUpdateInvoiceMetadataResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetInvoiceResponse result = ApiHelper.deserialize(responseBody,
-                GetInvoiceResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @return    Returns the GetInvoiceResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetInvoiceResponse getPartialInvoice(
-            final String subscriptionId) throws ApiException, IOException {
-        HttpRequest request = buildGetPartialInvoiceRequest(subscriptionId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetPartialInvoiceResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getPartialInvoice.
-     */
-    private HttpRequest buildGetPartialInvoiceRequest(
-            final String subscriptionId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/partial-invoice");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getPartialInvoice.
-     * @return An object of type GetInvoiceResponse
-     */
-    private GetInvoiceResponse handleGetPartialInvoiceResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetInvoiceResponse result = ApiHelper.deserialize(responseBody,
-                GetInvoiceResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Cancels an invoice.
-     * @param  invoiceId  Required parameter: Invoice id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetInvoiceResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetInvoiceResponse cancelInvoice(
-            final String invoiceId,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildCancelInvoiceRequest(invoiceId, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleCancelInvoiceResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for cancelInvoice.
-     */
-    private HttpRequest buildCancelInvoiceRequest(
-            final String invoiceId,
-            final String idempotencyKey) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/invoices/{invoice_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("invoice_id",
-                new SimpleEntry<Object, Boolean>(invoiceId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().delete(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for cancelInvoice.
-     * @return An object of type GetInvoiceResponse
-     */
-    private GetInvoiceResponse handleCancelInvoiceResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetInvoiceResponse result = ApiHelper.deserialize(responseBody,
-                GetInvoiceResponse.class);
-
-        return result;
-    }
-
-    /**
      * Create an Invoice.
      * @param  subscriptionId  Required parameter: Subscription Id
      * @param  cycleId  Required parameter: Cycle Id
@@ -447,28 +235,31 @@ public final class DefaultInvoicesController extends BaseController implements I
     }
 
     /**
-     * Gets an invoice.
-     * @param  invoiceId  Required parameter: Invoice Id
+     * Cancels an invoice.
+     * @param  invoiceId  Required parameter: Invoice id
+     * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetInvoiceResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetInvoiceResponse getInvoice(
-            final String invoiceId) throws ApiException, IOException {
-        HttpRequest request = buildGetInvoiceRequest(invoiceId);
+    public GetInvoiceResponse cancelInvoice(
+            final String invoiceId,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildCancelInvoiceRequest(invoiceId, idempotencyKey);
         authManagers.get("global").apply(request);
 
         HttpResponse response = getClientInstance().execute(request, false);
         HttpContext context = new HttpContext(request, response);
 
-        return handleGetInvoiceResponse(context);
+        return handleCancelInvoiceResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for getInvoice.
+     * Builds the HttpRequest object for cancelInvoice.
      */
-    private HttpRequest buildGetInvoiceRequest(
-            final String invoiceId) {
+    private HttpRequest buildCancelInvoiceRequest(
+            final String invoiceId,
+            final String idempotencyKey) {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
@@ -484,6 +275,149 @@ public final class DefaultInvoicesController extends BaseController implements I
 
         //load all headers for the outgoing API request
         Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().delete(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for cancelInvoice.
+     * @return An object of type GetInvoiceResponse
+     */
+    private GetInvoiceResponse handleCancelInvoiceResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetInvoiceResponse result = ApiHelper.deserialize(responseBody,
+                GetInvoiceResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Updates the metadata from an invoice.
+     * @param  invoiceId  Required parameter: The invoice id
+     * @param  request  Required parameter: Request for updating the invoice metadata
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetInvoiceResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetInvoiceResponse updateInvoiceMetadata(
+            final String invoiceId,
+            final UpdateMetadataRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateInvoiceMetadataRequest(invoiceId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateInvoiceMetadataResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateInvoiceMetadata.
+     */
+    private HttpRequest buildUpdateInvoiceMetadataRequest(
+            final String invoiceId,
+            final UpdateMetadataRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/invoices/{invoice_id}/metadata");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("invoice_id",
+                new SimpleEntry<Object, Boolean>(invoiceId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateInvoiceMetadata.
+     * @return An object of type GetInvoiceResponse
+     */
+    private GetInvoiceResponse handleUpdateInvoiceMetadataResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetInvoiceResponse result = ApiHelper.deserialize(responseBody,
+                GetInvoiceResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @return    Returns the GetInvoiceResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetInvoiceResponse getPartialInvoice(
+            final String subscriptionId) throws ApiException, IOException {
+        HttpRequest request = buildGetPartialInvoiceRequest(subscriptionId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetPartialInvoiceResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getPartialInvoice.
+     */
+    private HttpRequest buildGetPartialInvoiceRequest(
+            final String subscriptionId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/partial-invoice");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
         headers.add("user-agent", BaseController.userAgent);
         headers.add("accept", "application/json");
 
@@ -494,10 +428,10 @@ public final class DefaultInvoicesController extends BaseController implements I
     }
 
     /**
-     * Processes the response for getInvoice.
+     * Processes the response for getPartialInvoice.
      * @return An object of type GetInvoiceResponse
      */
-    private GetInvoiceResponse handleGetInvoiceResponse(
+    private GetInvoiceResponse handleGetPartialInvoiceResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -575,6 +509,72 @@ public final class DefaultInvoicesController extends BaseController implements I
      * @return An object of type GetInvoiceResponse
      */
     private GetInvoiceResponse handleUpdateInvoiceStatusResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetInvoiceResponse result = ApiHelper.deserialize(responseBody,
+                GetInvoiceResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Gets an invoice.
+     * @param  invoiceId  Required parameter: Invoice Id
+     * @return    Returns the GetInvoiceResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetInvoiceResponse getInvoice(
+            final String invoiceId) throws ApiException, IOException {
+        HttpRequest request = buildGetInvoiceRequest(invoiceId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetInvoiceResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getInvoice.
+     */
+    private HttpRequest buildGetInvoiceRequest(
+            final String invoiceId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/invoices/{invoice_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("invoice_id",
+                new SimpleEntry<Object, Boolean>(invoiceId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getInvoice.
+     * @return An object of type GetInvoiceResponse
+     */
+    private GetInvoiceResponse handleGetInvoiceResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 

--- a/src/main/java/me/pagar/api/controllers/DefaultOrdersController.java
+++ b/src/main/java/me/pagar/api/controllers/DefaultOrdersController.java
@@ -142,6 +142,283 @@ public final class DefaultOrdersController extends BaseController implements Ord
     /**
      * @param  orderId  Required parameter: Order Id
      * @param  itemId  Required parameter: Item Id
+     * @return    Returns the GetOrderItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetOrderItemResponse getOrderItem(
+            final String orderId,
+            final String itemId) throws ApiException, IOException {
+        HttpRequest request = buildGetOrderItemRequest(orderId, itemId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetOrderItemResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getOrderItem.
+     */
+    private HttpRequest buildGetOrderItemRequest(
+            final String orderId,
+            final String itemId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/orders/{orderId}/items/{itemId}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("orderId",
+                new SimpleEntry<Object, Boolean>(orderId, true));
+        templateParameters.put("itemId",
+                new SimpleEntry<Object, Boolean>(itemId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getOrderItem.
+     * @return An object of type GetOrderItemResponse
+     */
+    private GetOrderItemResponse handleGetOrderItemResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetOrderItemResponse result = ApiHelper.deserialize(responseBody,
+                GetOrderItemResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Gets an order.
+     * @param  orderId  Required parameter: Order id
+     * @return    Returns the GetOrderResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetOrderResponse getOrder(
+            final String orderId) throws ApiException, IOException {
+        HttpRequest request = buildGetOrderRequest(orderId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetOrderResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getOrder.
+     */
+    private HttpRequest buildGetOrderRequest(
+            final String orderId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/orders/{order_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("order_id",
+                new SimpleEntry<Object, Boolean>(orderId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getOrder.
+     * @return An object of type GetOrderResponse
+     */
+    private GetOrderResponse handleGetOrderResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetOrderResponse result = ApiHelper.deserialize(responseBody,
+                GetOrderResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  id  Required parameter: Order Id
+     * @param  request  Required parameter: Update Order Model
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetOrderResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetOrderResponse closeOrder(
+            final String id,
+            final UpdateOrderStatusRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCloseOrderRequest(id, request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCloseOrderResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for closeOrder.
+     */
+    private HttpRequest buildCloseOrderRequest(
+            final String id,
+            final UpdateOrderStatusRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/orders/{id}/closed");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("id",
+                new SimpleEntry<Object, Boolean>(id, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for closeOrder.
+     * @return An object of type GetOrderResponse
+     */
+    private GetOrderResponse handleCloseOrderResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetOrderResponse result = ApiHelper.deserialize(responseBody,
+                GetOrderResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a new Order.
+     * @param  body  Required parameter: Request for creating an order
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetOrderResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetOrderResponse createOrder(
+            final CreateOrderRequest body,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildCreateOrderRequest(body, idempotencyKey);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleCreateOrderResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createOrder.
+     */
+    private HttpRequest buildCreateOrderRequest(
+            final CreateOrderRequest body,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/orders");
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(body);
+        HttpRequest request = getClientInstance().postBody(queryBuilder, headers, null, bodyJson);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for createOrder.
+     * @return An object of type GetOrderResponse
+     */
+    private GetOrderResponse handleCreateOrderResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetOrderResponse result = ApiHelper.deserialize(responseBody,
+                GetOrderResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  orderId  Required parameter: Order Id
+     * @param  itemId  Required parameter: Item Id
      * @param  request  Required parameter: Item Model
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetOrderItemResponse response from the API call
@@ -290,366 +567,6 @@ public final class DefaultOrdersController extends BaseController implements Ord
     }
 
     /**
-     * @param  orderId  Required parameter: Order Id
-     * @param  itemId  Required parameter: Item Id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetOrderItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetOrderItemResponse deleteOrderItem(
-            final String orderId,
-            final String itemId,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildDeleteOrderItemRequest(orderId, itemId, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleDeleteOrderItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for deleteOrderItem.
-     */
-    private HttpRequest buildDeleteOrderItemRequest(
-            final String orderId,
-            final String itemId,
-            final String idempotencyKey) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/orders/{orderId}/items/{itemId}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("orderId",
-                new SimpleEntry<Object, Boolean>(orderId, true));
-        templateParameters.put("itemId",
-                new SimpleEntry<Object, Boolean>(itemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().delete(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for deleteOrderItem.
-     * @return An object of type GetOrderItemResponse
-     */
-    private GetOrderItemResponse handleDeleteOrderItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetOrderItemResponse result = ApiHelper.deserialize(responseBody,
-                GetOrderItemResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  id  Required parameter: Order Id
-     * @param  request  Required parameter: Update Order Model
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetOrderResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetOrderResponse closeOrder(
-            final String id,
-            final UpdateOrderStatusRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCloseOrderRequest(id, request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCloseOrderResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for closeOrder.
-     */
-    private HttpRequest buildCloseOrderRequest(
-            final String id,
-            final UpdateOrderStatusRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/orders/{id}/closed");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("id",
-                new SimpleEntry<Object, Boolean>(id, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for closeOrder.
-     * @return An object of type GetOrderResponse
-     */
-    private GetOrderResponse handleCloseOrderResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetOrderResponse result = ApiHelper.deserialize(responseBody,
-                GetOrderResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Creates a new Order.
-     * @param  body  Required parameter: Request for creating an order
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetOrderResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetOrderResponse createOrder(
-            final CreateOrderRequest body,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildCreateOrderRequest(body, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleCreateOrderResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createOrder.
-     */
-    private HttpRequest buildCreateOrderRequest(
-            final CreateOrderRequest body,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/orders");
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(body);
-        HttpRequest request = getClientInstance().postBody(queryBuilder, headers, null, bodyJson);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for createOrder.
-     * @return An object of type GetOrderResponse
-     */
-    private GetOrderResponse handleCreateOrderResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetOrderResponse result = ApiHelper.deserialize(responseBody,
-                GetOrderResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  orderId  Required parameter: Order Id
-     * @param  request  Required parameter: Order Item Model
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetOrderItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetOrderItemResponse createOrderItem(
-            final String orderId,
-            final CreateOrderItemRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreateOrderItemRequest(orderId, request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCreateOrderItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createOrderItem.
-     */
-    private HttpRequest buildCreateOrderItemRequest(
-            final String orderId,
-            final CreateOrderItemRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/orders/{orderId}/items");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("orderId",
-                new SimpleEntry<Object, Boolean>(orderId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for createOrderItem.
-     * @return An object of type GetOrderItemResponse
-     */
-    private GetOrderItemResponse handleCreateOrderItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetOrderItemResponse result = ApiHelper.deserialize(responseBody,
-                GetOrderItemResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  orderId  Required parameter: Order Id
-     * @param  itemId  Required parameter: Item Id
-     * @return    Returns the GetOrderItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetOrderItemResponse getOrderItem(
-            final String orderId,
-            final String itemId) throws ApiException, IOException {
-        HttpRequest request = buildGetOrderItemRequest(orderId, itemId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetOrderItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getOrderItem.
-     */
-    private HttpRequest buildGetOrderItemRequest(
-            final String orderId,
-            final String itemId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/orders/{orderId}/items/{itemId}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("orderId",
-                new SimpleEntry<Object, Boolean>(orderId, true));
-        templateParameters.put("itemId",
-                new SimpleEntry<Object, Boolean>(itemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getOrderItem.
-     * @return An object of type GetOrderItemResponse
-     */
-    private GetOrderItemResponse handleGetOrderItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetOrderItemResponse result = ApiHelper.deserialize(responseBody,
-                GetOrderItemResponse.class);
-
-        return result;
-    }
-
-    /**
      * Updates the metadata from an order.
      * @param  orderId  Required parameter: The order id
      * @param  request  Required parameter: Request for updating the order metadata
@@ -727,57 +644,65 @@ public final class DefaultOrdersController extends BaseController implements Ord
     }
 
     /**
-     * Gets an order.
-     * @param  orderId  Required parameter: Order id
-     * @return    Returns the GetOrderResponse response from the API call
+     * @param  orderId  Required parameter: Order Id
+     * @param  itemId  Required parameter: Item Id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetOrderItemResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetOrderResponse getOrder(
-            final String orderId) throws ApiException, IOException {
-        HttpRequest request = buildGetOrderRequest(orderId);
+    public GetOrderItemResponse deleteOrderItem(
+            final String orderId,
+            final String itemId,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildDeleteOrderItemRequest(orderId, itemId, idempotencyKey);
         authManagers.get("global").apply(request);
 
         HttpResponse response = getClientInstance().execute(request, false);
         HttpContext context = new HttpContext(request, response);
 
-        return handleGetOrderResponse(context);
+        return handleDeleteOrderItemResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for getOrder.
+     * Builds the HttpRequest object for deleteOrderItem.
      */
-    private HttpRequest buildGetOrderRequest(
-            final String orderId) {
+    private HttpRequest buildDeleteOrderItemRequest(
+            final String orderId,
+            final String itemId,
+            final String idempotencyKey) {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/orders/{order_id}");
+                + "/orders/{orderId}/items/{itemId}");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("order_id",
+        templateParameters.put("orderId",
                 new SimpleEntry<Object, Boolean>(orderId, true));
+        templateParameters.put("itemId",
+                new SimpleEntry<Object, Boolean>(itemId, true));
         ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
 
         //load all headers for the outgoing API request
         Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
         headers.add("user-agent", BaseController.userAgent);
         headers.add("accept", "application/json");
 
         //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+        HttpRequest request = getClientInstance().delete(queryBuilder, headers, null, null);
 
         return request;
     }
 
     /**
-     * Processes the response for getOrder.
-     * @return An object of type GetOrderResponse
+     * Processes the response for deleteOrderItem.
+     * @return An object of type GetOrderItemResponse
      */
-    private GetOrderResponse handleGetOrderResponse(
+    private GetOrderItemResponse handleDeleteOrderItemResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -786,8 +711,83 @@ public final class DefaultOrdersController extends BaseController implements Ord
 
         //extract result from the http response
         String responseBody = ((HttpStringResponse) response).getBody();
-        GetOrderResponse result = ApiHelper.deserialize(responseBody,
-                GetOrderResponse.class);
+        GetOrderItemResponse result = ApiHelper.deserialize(responseBody,
+                GetOrderItemResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  orderId  Required parameter: Order Id
+     * @param  request  Required parameter: Order Item Model
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetOrderItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetOrderItemResponse createOrderItem(
+            final String orderId,
+            final CreateOrderItemRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreateOrderItemRequest(orderId, request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCreateOrderItemResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createOrderItem.
+     */
+    private HttpRequest buildCreateOrderItemRequest(
+            final String orderId,
+            final CreateOrderItemRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/orders/{orderId}/items");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("orderId",
+                new SimpleEntry<Object, Boolean>(orderId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for createOrderItem.
+     * @return An object of type GetOrderItemResponse
+     */
+    private GetOrderItemResponse handleCreateOrderItemResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetOrderItemResponse result = ApiHelper.deserialize(responseBody,
+                GetOrderItemResponse.class);
 
         return result;
     }

--- a/src/main/java/me/pagar/api/controllers/DefaultPlansController.java
+++ b/src/main/java/me/pagar/api/controllers/DefaultPlansController.java
@@ -116,31 +116,34 @@ public final class DefaultPlansController extends BaseController implements Plan
     }
 
     /**
-     * Deletes a plan.
+     * Updates a plan.
      * @param  planId  Required parameter: Plan id
+     * @param  request  Required parameter: Request for updating a plan
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetPlanResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetPlanResponse deletePlan(
+    public GetPlanResponse updatePlan(
             final String planId,
+            final UpdatePlanRequest request,
             final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildDeletePlanRequest(planId, idempotencyKey);
-        authManagers.get("global").apply(request);
+        HttpRequest internalRequest = buildUpdatePlanRequest(planId, request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
 
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
 
-        return handleDeletePlanResponse(context);
+        return handleUpdatePlanResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for deletePlan.
+     * Builds the HttpRequest object for updatePlan.
      */
-    private HttpRequest buildDeletePlanRequest(
+    private HttpRequest buildUpdatePlanRequest(
             final String planId,
-            final String idempotencyKey) {
+            final UpdatePlanRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
@@ -159,18 +162,21 @@ public final class DefaultPlansController extends BaseController implements Plan
         headers.add("idempotency-key", idempotencyKey);
         headers.add("user-agent", BaseController.userAgent);
         headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
 
         //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().delete(queryBuilder, headers, null, null);
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().putBody(queryBuilder, headers, null,
+                bodyJson);
 
-        return request;
+        return internalRequest;
     }
 
     /**
-     * Processes the response for deletePlan.
+     * Processes the response for updatePlan.
      * @return An object of type GetPlanResponse
      */
-    private GetPlanResponse handleDeletePlanResponse(
+    private GetPlanResponse handleUpdatePlanResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -248,299 +254,6 @@ public final class DefaultPlansController extends BaseController implements Plan
      * @return An object of type GetPlanResponse
      */
     private GetPlanResponse handleUpdatePlanMetadataResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetPlanResponse result = ApiHelper.deserialize(responseBody,
-                GetPlanResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Updates a plan item.
-     * @param  planId  Required parameter: Plan id
-     * @param  planItemId  Required parameter: Plan item id
-     * @param  body  Required parameter: Request for updating the plan item
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetPlanItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetPlanItemResponse updatePlanItem(
-            final String planId,
-            final String planItemId,
-            final UpdatePlanItemRequest body,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildUpdatePlanItemRequest(planId, planItemId, body, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleUpdatePlanItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updatePlanItem.
-     */
-    private HttpRequest buildUpdatePlanItemRequest(
-            final String planId,
-            final String planItemId,
-            final UpdatePlanItemRequest body,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/plans/{plan_id}/items/{plan_item_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("plan_id",
-                new SimpleEntry<Object, Boolean>(planId, true));
-        templateParameters.put("plan_item_id",
-                new SimpleEntry<Object, Boolean>(planItemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(body);
-        HttpRequest request = getClientInstance().putBody(queryBuilder, headers, null, bodyJson);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for updatePlanItem.
-     * @return An object of type GetPlanItemResponse
-     */
-    private GetPlanItemResponse handleUpdatePlanItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetPlanItemResponse result = ApiHelper.deserialize(responseBody,
-                GetPlanItemResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Adds a new item to a plan.
-     * @param  planId  Required parameter: Plan id
-     * @param  request  Required parameter: Request for creating a plan item
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetPlanItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetPlanItemResponse createPlanItem(
-            final String planId,
-            final CreatePlanItemRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreatePlanItemRequest(planId, request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCreatePlanItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createPlanItem.
-     */
-    private HttpRequest buildCreatePlanItemRequest(
-            final String planId,
-            final CreatePlanItemRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/plans/{plan_id}/items");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("plan_id",
-                new SimpleEntry<Object, Boolean>(planId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for createPlanItem.
-     * @return An object of type GetPlanItemResponse
-     */
-    private GetPlanItemResponse handleCreatePlanItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetPlanItemResponse result = ApiHelper.deserialize(responseBody,
-                GetPlanItemResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Gets a plan item.
-     * @param  planId  Required parameter: Plan id
-     * @param  planItemId  Required parameter: Plan item id
-     * @return    Returns the GetPlanItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetPlanItemResponse getPlanItem(
-            final String planId,
-            final String planItemId) throws ApiException, IOException {
-        HttpRequest request = buildGetPlanItemRequest(planId, planItemId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetPlanItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getPlanItem.
-     */
-    private HttpRequest buildGetPlanItemRequest(
-            final String planId,
-            final String planItemId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/plans/{plan_id}/items/{plan_item_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("plan_id",
-                new SimpleEntry<Object, Boolean>(planId, true));
-        templateParameters.put("plan_item_id",
-                new SimpleEntry<Object, Boolean>(planItemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getPlanItem.
-     * @return An object of type GetPlanItemResponse
-     */
-    private GetPlanItemResponse handleGetPlanItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetPlanItemResponse result = ApiHelper.deserialize(responseBody,
-                GetPlanItemResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Creates a new plan.
-     * @param  body  Required parameter: Request for creating a plan
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetPlanResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetPlanResponse createPlan(
-            final CreatePlanRequest body,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildCreatePlanRequest(body, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleCreatePlanResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createPlan.
-     */
-    private HttpRequest buildCreatePlanRequest(
-            final CreatePlanRequest body,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/plans");
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(body);
-        HttpRequest request = getClientInstance().postBody(queryBuilder, headers, null, bodyJson);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for createPlan.
-     * @return An object of type GetPlanResponse
-     */
-    private GetPlanResponse handleCreatePlanResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -721,34 +434,102 @@ public final class DefaultPlansController extends BaseController implements Plan
     }
 
     /**
-     * Updates a plan.
+     * Gets a plan item.
      * @param  planId  Required parameter: Plan id
-     * @param  request  Required parameter: Request for updating a plan
+     * @param  planItemId  Required parameter: Plan item id
+     * @return    Returns the GetPlanItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetPlanItemResponse getPlanItem(
+            final String planId,
+            final String planItemId) throws ApiException, IOException {
+        HttpRequest request = buildGetPlanItemRequest(planId, planItemId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetPlanItemResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getPlanItem.
+     */
+    private HttpRequest buildGetPlanItemRequest(
+            final String planId,
+            final String planItemId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/plans/{plan_id}/items/{plan_item_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("plan_id",
+                new SimpleEntry<Object, Boolean>(planId, true));
+        templateParameters.put("plan_item_id",
+                new SimpleEntry<Object, Boolean>(planItemId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getPlanItem.
+     * @return An object of type GetPlanItemResponse
+     */
+    private GetPlanItemResponse handleGetPlanItemResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetPlanItemResponse result = ApiHelper.deserialize(responseBody,
+                GetPlanItemResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Deletes a plan.
+     * @param  planId  Required parameter: Plan id
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetPlanResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetPlanResponse updatePlan(
+    public GetPlanResponse deletePlan(
             final String planId,
-            final UpdatePlanRequest request,
             final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdatePlanRequest(planId, request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
+        HttpRequest request = buildDeletePlanRequest(planId, idempotencyKey);
+        authManagers.get("global").apply(request);
 
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
 
-        return handleUpdatePlanResponse(context);
+        return handleDeletePlanResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for updatePlan.
+     * Builds the HttpRequest object for deletePlan.
      */
-    private HttpRequest buildUpdatePlanRequest(
+    private HttpRequest buildDeletePlanRequest(
             final String planId,
-            final UpdatePlanRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
+            final String idempotencyKey) {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
@@ -767,21 +548,240 @@ public final class DefaultPlansController extends BaseController implements Plan
         headers.add("idempotency-key", idempotencyKey);
         headers.add("user-agent", BaseController.userAgent);
         headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().delete(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for deletePlan.
+     * @return An object of type GetPlanResponse
+     */
+    private GetPlanResponse handleDeletePlanResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetPlanResponse result = ApiHelper.deserialize(responseBody,
+                GetPlanResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Updates a plan item.
+     * @param  planId  Required parameter: Plan id
+     * @param  planItemId  Required parameter: Plan item id
+     * @param  body  Required parameter: Request for updating the plan item
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetPlanItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetPlanItemResponse updatePlanItem(
+            final String planId,
+            final String planItemId,
+            final UpdatePlanItemRequest body,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildUpdatePlanItemRequest(planId, planItemId, body, idempotencyKey);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleUpdatePlanItemResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updatePlanItem.
+     */
+    private HttpRequest buildUpdatePlanItemRequest(
+            final String planId,
+            final String planItemId,
+            final UpdatePlanItemRequest body,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/plans/{plan_id}/items/{plan_item_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("plan_id",
+                new SimpleEntry<Object, Boolean>(planId, true));
+        templateParameters.put("plan_item_id",
+                new SimpleEntry<Object, Boolean>(planItemId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(body);
+        HttpRequest request = getClientInstance().putBody(queryBuilder, headers, null, bodyJson);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for updatePlanItem.
+     * @return An object of type GetPlanItemResponse
+     */
+    private GetPlanItemResponse handleUpdatePlanItemResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetPlanItemResponse result = ApiHelper.deserialize(responseBody,
+                GetPlanItemResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Adds a new item to a plan.
+     * @param  planId  Required parameter: Plan id
+     * @param  request  Required parameter: Request for creating a plan item
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetPlanItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetPlanItemResponse createPlanItem(
+            final String planId,
+            final CreatePlanItemRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreatePlanItemRequest(planId, request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCreatePlanItemResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createPlanItem.
+     */
+    private HttpRequest buildCreatePlanItemRequest(
+            final String planId,
+            final CreatePlanItemRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/plans/{plan_id}/items");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("plan_id",
+                new SimpleEntry<Object, Boolean>(planId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
         headers.add("content-type", "application/json");
 
         //prepare and invoke the API call request to fetch the response
         String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().putBody(queryBuilder, headers, null,
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
                 bodyJson);
 
         return internalRequest;
     }
 
     /**
-     * Processes the response for updatePlan.
+     * Processes the response for createPlanItem.
+     * @return An object of type GetPlanItemResponse
+     */
+    private GetPlanItemResponse handleCreatePlanItemResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetPlanItemResponse result = ApiHelper.deserialize(responseBody,
+                GetPlanItemResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a new plan.
+     * @param  body  Required parameter: Request for creating a plan
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetPlanResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetPlanResponse createPlan(
+            final CreatePlanRequest body,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildCreatePlanRequest(body, idempotencyKey);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleCreatePlanResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createPlan.
+     */
+    private HttpRequest buildCreatePlanRequest(
+            final CreatePlanRequest body,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/plans");
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(body);
+        HttpRequest request = getClientInstance().postBody(queryBuilder, headers, null, bodyJson);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for createPlan.
      * @return An object of type GetPlanResponse
      */
-    private GetPlanResponse handleUpdatePlanResponse(
+    private GetPlanResponse handleCreatePlanResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 

--- a/src/main/java/me/pagar/api/controllers/DefaultRecipientsController.java
+++ b/src/main/java/me/pagar/api/controllers/DefaultRecipientsController.java
@@ -363,153 +363,6 @@ public final class DefaultRecipientsController extends BaseController implements
     }
 
     /**
-     * @param  recipientId  Required parameter: Example:
-     * @param  withdrawalId  Required parameter: Example:
-     * @return    Returns the GetWithdrawResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetWithdrawResponse getWithdrawById(
-            final String recipientId,
-            final String withdrawalId) throws ApiException, IOException {
-        HttpRequest request = buildGetWithdrawByIdRequest(recipientId, withdrawalId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetWithdrawByIdResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getWithdrawById.
-     */
-    private HttpRequest buildGetWithdrawByIdRequest(
-            final String recipientId,
-            final String withdrawalId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/recipients/{recipient_id}/withdrawals/{withdrawal_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("recipient_id",
-                new SimpleEntry<Object, Boolean>(recipientId, true));
-        templateParameters.put("withdrawal_id",
-                new SimpleEntry<Object, Boolean>(withdrawalId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getWithdrawById.
-     * @return An object of type GetWithdrawResponse
-     */
-    private GetWithdrawResponse handleGetWithdrawByIdResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetWithdrawResponse result = ApiHelper.deserialize(responseBody,
-                GetWithdrawResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Updates the default bank account from a recipient.
-     * @param  recipientId  Required parameter: Recipient id
-     * @param  request  Required parameter: Bank account data
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetRecipientResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetRecipientResponse updateRecipientDefaultBankAccount(
-            final String recipientId,
-            final UpdateRecipientBankAccountRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateRecipientDefaultBankAccountRequest(recipientId,
-                request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateRecipientDefaultBankAccountResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateRecipientDefaultBankAccount.
-     */
-    private HttpRequest buildUpdateRecipientDefaultBankAccountRequest(
-            final String recipientId,
-            final UpdateRecipientBankAccountRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/recipients/{recipient_id}/default-bank-account");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("recipient_id",
-                new SimpleEntry<Object, Boolean>(recipientId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateRecipientDefaultBankAccount.
-     * @return An object of type GetRecipientResponse
-     */
-    private GetRecipientResponse handleUpdateRecipientDefaultBankAccountResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetRecipientResponse result = ApiHelper.deserialize(responseBody,
-                GetRecipientResponse.class);
-
-        return result;
-    }
-
-    /**
      * Updates recipient metadata.
      * @param  recipientId  Required parameter: Recipient id
      * @param  request  Required parameter: Metadata
@@ -587,97 +440,6 @@ public final class DefaultRecipientsController extends BaseController implements
     }
 
     /**
-     * Gets a paginated list of transfers for the recipient.
-     * @param  recipientId  Required parameter: Recipient id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @param  status  Optional parameter: Filter for transfer status
-     * @param  createdSince  Optional parameter: Filter for start range of transfer creation date
-     * @param  createdUntil  Optional parameter: Filter for end range of transfer creation date
-     * @return    Returns the ListTransferResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public ListTransferResponse getTransfers(
-            final String recipientId,
-            final Integer page,
-            final Integer size,
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) throws ApiException, IOException {
-        HttpRequest request = buildGetTransfersRequest(recipientId, page, size, status,
-                createdSince, createdUntil);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetTransfersResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getTransfers.
-     */
-    private HttpRequest buildGetTransfersRequest(
-            final String recipientId,
-            final Integer page,
-            final Integer size,
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/recipients/{recipient_id}/transfers");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("recipient_id",
-                new SimpleEntry<Object, Boolean>(recipientId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all query parameters
-        Map<String, Object> queryParameters = new HashMap<>();
-        queryParameters.put("page", page);
-        queryParameters.put("size", size);
-        queryParameters.put("status", status);
-        queryParameters.put("created_since", DateTimeHelper.toRfc8601DateTime(createdSince));
-        queryParameters.put("created_until", DateTimeHelper.toRfc8601DateTime(createdUntil));
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
-                null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getTransfers.
-     * @return An object of type ListTransferResponse
-     */
-    private ListTransferResponse handleGetTransfersResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        ListTransferResponse result = ApiHelper.deserialize(responseBody,
-                ListTransferResponse.class);
-
-        return result;
-    }
-
-    /**
      * Gets a transfer.
      * @param  recipientId  Required parameter: Recipient id
      * @param  transferId  Required parameter: Transfer id
@@ -744,154 +506,6 @@ public final class DefaultRecipientsController extends BaseController implements
         String responseBody = ((HttpStringResponse) response).getBody();
         GetTransferResponse result = ApiHelper.deserialize(responseBody,
                 GetTransferResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  recipientId  Required parameter: Example:
-     * @param  request  Required parameter: Example:
-     * @return    Returns the GetWithdrawResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetWithdrawResponse createWithdraw(
-            final String recipientId,
-            final CreateWithdrawRequest request) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreateWithdrawRequest(recipientId, request);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCreateWithdrawResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createWithdraw.
-     */
-    private HttpRequest buildCreateWithdrawRequest(
-            final String recipientId,
-            final CreateWithdrawRequest request) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/recipients/{recipient_id}/withdrawals");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("recipient_id",
-                new SimpleEntry<Object, Boolean>(recipientId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for createWithdraw.
-     * @return An object of type GetWithdrawResponse
-     */
-    private GetWithdrawResponse handleCreateWithdrawResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetWithdrawResponse result = ApiHelper.deserialize(responseBody,
-                GetWithdrawResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Updates recipient metadata.
-     * @param  recipientId  Required parameter: Recipient id
-     * @param  request  Required parameter: Metadata
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetRecipientResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetRecipientResponse updateAutomaticAnticipationSettings(
-            final String recipientId,
-            final UpdateAutomaticAnticipationSettingsRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateAutomaticAnticipationSettingsRequest(recipientId,
-                request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateAutomaticAnticipationSettingsResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateAutomaticAnticipationSettings.
-     */
-    private HttpRequest buildUpdateAutomaticAnticipationSettingsRequest(
-            final String recipientId,
-            final UpdateAutomaticAnticipationSettingsRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/recipients/{recipient_id}/automatic-anticipation-settings");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("recipient_id",
-                new SimpleEntry<Object, Boolean>(recipientId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateAutomaticAnticipationSettings.
-     * @return An object of type GetRecipientResponse
-     */
-    private GetRecipientResponse handleUpdateAutomaticAnticipationSettingsResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetRecipientResponse result = ApiHelper.deserialize(responseBody,
-                GetRecipientResponse.class);
 
         return result;
     }
@@ -1150,34 +764,113 @@ public final class DefaultRecipientsController extends BaseController implements
     }
 
     /**
-     * Retrieves recipient information.
-     * @param  recipientId  Required parameter: Recipiend id
+     * Updates the default bank account from a recipient.
+     * @param  recipientId  Required parameter: Recipient id
+     * @param  request  Required parameter: Bank account data
+     * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetRecipientResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetRecipientResponse getRecipient(
-            final String recipientId) throws ApiException, IOException {
-        HttpRequest request = buildGetRecipientRequest(recipientId);
-        authManagers.get("global").apply(request);
+    public GetRecipientResponse updateRecipientDefaultBankAccount(
+            final String recipientId,
+            final UpdateRecipientBankAccountRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateRecipientDefaultBankAccountRequest(recipientId,
+                request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
 
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
 
-        return handleGetRecipientResponse(context);
+        return handleUpdateRecipientDefaultBankAccountResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for getRecipient.
+     * Builds the HttpRequest object for updateRecipientDefaultBankAccount.
      */
-    private HttpRequest buildGetRecipientRequest(
-            final String recipientId) {
+    private HttpRequest buildUpdateRecipientDefaultBankAccountRequest(
+            final String recipientId,
+            final UpdateRecipientBankAccountRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/recipients/{recipient_id}");
+                + "/recipients/{recipient_id}/default-bank-account");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("recipient_id",
+                new SimpleEntry<Object, Boolean>(recipientId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateRecipientDefaultBankAccount.
+     * @return An object of type GetRecipientResponse
+     */
+    private GetRecipientResponse handleUpdateRecipientDefaultBankAccountResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetRecipientResponse result = ApiHelper.deserialize(responseBody,
+                GetRecipientResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  recipientId  Required parameter: Example:
+     * @param  request  Required parameter: Example:
+     * @return    Returns the GetWithdrawResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetWithdrawResponse createWithdraw(
+            final String recipientId,
+            final CreateWithdrawRequest request) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreateWithdrawRequest(recipientId, request);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCreateWithdrawResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createWithdraw.
+     */
+    private HttpRequest buildCreateWithdrawRequest(
+            final String recipientId,
+            final CreateWithdrawRequest request) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/recipients/{recipient_id}/withdrawals");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
@@ -1189,18 +882,21 @@ public final class DefaultRecipientsController extends BaseController implements
         Headers headers = new Headers();
         headers.add("user-agent", BaseController.userAgent);
         headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
 
         //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+                bodyJson);
 
-        return request;
+        return internalRequest;
     }
 
     /**
-     * Processes the response for getRecipient.
-     * @return An object of type GetRecipientResponse
+     * Processes the response for createWithdraw.
+     * @return An object of type GetWithdrawResponse
      */
-    private GetRecipientResponse handleGetRecipientResponse(
+    private GetWithdrawResponse handleCreateWithdrawResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -1209,8 +905,8 @@ public final class DefaultRecipientsController extends BaseController implements
 
         //extract result from the http response
         String responseBody = ((HttpStringResponse) response).getBody();
-        GetRecipientResponse result = ApiHelper.deserialize(responseBody,
-                GetRecipientResponse.class);
+        GetWithdrawResponse result = ApiHelper.deserialize(responseBody,
+                GetWithdrawResponse.class);
 
         return result;
     }
@@ -1277,97 +973,6 @@ public final class DefaultRecipientsController extends BaseController implements
         String responseBody = ((HttpStringResponse) response).getBody();
         GetBalanceResponse result = ApiHelper.deserialize(responseBody,
                 GetBalanceResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Gets a paginated list of transfers for the recipient.
-     * @param  recipientId  Required parameter: Example:
-     * @param  page  Optional parameter: Example:
-     * @param  size  Optional parameter: Example:
-     * @param  status  Optional parameter: Example:
-     * @param  createdSince  Optional parameter: Example:
-     * @param  createdUntil  Optional parameter: Example:
-     * @return    Returns the ListWithdrawals response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public ListWithdrawals getWithdrawals(
-            final String recipientId,
-            final Integer page,
-            final Integer size,
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) throws ApiException, IOException {
-        HttpRequest request = buildGetWithdrawalsRequest(recipientId, page, size, status,
-                createdSince, createdUntil);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetWithdrawalsResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getWithdrawals.
-     */
-    private HttpRequest buildGetWithdrawalsRequest(
-            final String recipientId,
-            final Integer page,
-            final Integer size,
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/recipients/{recipient_id}/withdrawals");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("recipient_id",
-                new SimpleEntry<Object, Boolean>(recipientId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all query parameters
-        Map<String, Object> queryParameters = new HashMap<>();
-        queryParameters.put("page", page);
-        queryParameters.put("size", size);
-        queryParameters.put("status", status);
-        queryParameters.put("created_since", DateTimeHelper.toRfc8601DateTime(createdSince));
-        queryParameters.put("created_until", DateTimeHelper.toRfc8601DateTime(createdUntil));
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
-                null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getWithdrawals.
-     * @return An object of type ListWithdrawals
-     */
-    private ListWithdrawals handleGetWithdrawalsResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        ListWithdrawals result = ApiHelper.deserialize(responseBody,
-                ListWithdrawals.class);
 
         return result;
     }
@@ -1512,6 +1117,401 @@ public final class DefaultRecipientsController extends BaseController implements
         String responseBody = ((HttpStringResponse) response).getBody();
         GetRecipientResponse result = ApiHelper.deserialize(responseBody,
                 GetRecipientResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Updates recipient metadata.
+     * @param  recipientId  Required parameter: Recipient id
+     * @param  request  Required parameter: Metadata
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetRecipientResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetRecipientResponse updateAutomaticAnticipationSettings(
+            final String recipientId,
+            final UpdateAutomaticAnticipationSettingsRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateAutomaticAnticipationSettingsRequest(recipientId,
+                request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateAutomaticAnticipationSettingsResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateAutomaticAnticipationSettings.
+     */
+    private HttpRequest buildUpdateAutomaticAnticipationSettingsRequest(
+            final String recipientId,
+            final UpdateAutomaticAnticipationSettingsRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/recipients/{recipient_id}/automatic-anticipation-settings");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("recipient_id",
+                new SimpleEntry<Object, Boolean>(recipientId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateAutomaticAnticipationSettings.
+     * @return An object of type GetRecipientResponse
+     */
+    private GetRecipientResponse handleUpdateAutomaticAnticipationSettingsResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetRecipientResponse result = ApiHelper.deserialize(responseBody,
+                GetRecipientResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Retrieves recipient information.
+     * @param  recipientId  Required parameter: Recipiend id
+     * @return    Returns the GetRecipientResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetRecipientResponse getRecipient(
+            final String recipientId) throws ApiException, IOException {
+        HttpRequest request = buildGetRecipientRequest(recipientId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetRecipientResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getRecipient.
+     */
+    private HttpRequest buildGetRecipientRequest(
+            final String recipientId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/recipients/{recipient_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("recipient_id",
+                new SimpleEntry<Object, Boolean>(recipientId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getRecipient.
+     * @return An object of type GetRecipientResponse
+     */
+    private GetRecipientResponse handleGetRecipientResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetRecipientResponse result = ApiHelper.deserialize(responseBody,
+                GetRecipientResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Gets a paginated list of transfers for the recipient.
+     * @param  recipientId  Required parameter: Example:
+     * @param  page  Optional parameter: Example:
+     * @param  size  Optional parameter: Example:
+     * @param  status  Optional parameter: Example:
+     * @param  createdSince  Optional parameter: Example:
+     * @param  createdUntil  Optional parameter: Example:
+     * @return    Returns the ListWithdrawals response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public ListWithdrawals getWithdrawals(
+            final String recipientId,
+            final Integer page,
+            final Integer size,
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) throws ApiException, IOException {
+        HttpRequest request = buildGetWithdrawalsRequest(recipientId, page, size, status,
+                createdSince, createdUntil);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetWithdrawalsResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getWithdrawals.
+     */
+    private HttpRequest buildGetWithdrawalsRequest(
+            final String recipientId,
+            final Integer page,
+            final Integer size,
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/recipients/{recipient_id}/withdrawals");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("recipient_id",
+                new SimpleEntry<Object, Boolean>(recipientId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all query parameters
+        Map<String, Object> queryParameters = new HashMap<>();
+        queryParameters.put("page", page);
+        queryParameters.put("size", size);
+        queryParameters.put("status", status);
+        queryParameters.put("created_since", DateTimeHelper.toRfc8601DateTime(createdSince));
+        queryParameters.put("created_until", DateTimeHelper.toRfc8601DateTime(createdUntil));
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
+                null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getWithdrawals.
+     * @return An object of type ListWithdrawals
+     */
+    private ListWithdrawals handleGetWithdrawalsResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        ListWithdrawals result = ApiHelper.deserialize(responseBody,
+                ListWithdrawals.class);
+
+        return result;
+    }
+
+    /**
+     * @param  recipientId  Required parameter: Example:
+     * @param  withdrawalId  Required parameter: Example:
+     * @return    Returns the GetWithdrawResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetWithdrawResponse getWithdrawById(
+            final String recipientId,
+            final String withdrawalId) throws ApiException, IOException {
+        HttpRequest request = buildGetWithdrawByIdRequest(recipientId, withdrawalId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetWithdrawByIdResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getWithdrawById.
+     */
+    private HttpRequest buildGetWithdrawByIdRequest(
+            final String recipientId,
+            final String withdrawalId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/recipients/{recipient_id}/withdrawals/{withdrawal_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("recipient_id",
+                new SimpleEntry<Object, Boolean>(recipientId, true));
+        templateParameters.put("withdrawal_id",
+                new SimpleEntry<Object, Boolean>(withdrawalId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getWithdrawById.
+     * @return An object of type GetWithdrawResponse
+     */
+    private GetWithdrawResponse handleGetWithdrawByIdResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetWithdrawResponse result = ApiHelper.deserialize(responseBody,
+                GetWithdrawResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Gets a paginated list of transfers for the recipient.
+     * @param  recipientId  Required parameter: Recipient id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @param  status  Optional parameter: Filter for transfer status
+     * @param  createdSince  Optional parameter: Filter for start range of transfer creation date
+     * @param  createdUntil  Optional parameter: Filter for end range of transfer creation date
+     * @return    Returns the ListTransferResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public ListTransferResponse getTransfers(
+            final String recipientId,
+            final Integer page,
+            final Integer size,
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) throws ApiException, IOException {
+        HttpRequest request = buildGetTransfersRequest(recipientId, page, size, status,
+                createdSince, createdUntil);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetTransfersResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getTransfers.
+     */
+    private HttpRequest buildGetTransfersRequest(
+            final String recipientId,
+            final Integer page,
+            final Integer size,
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/recipients/{recipient_id}/transfers");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("recipient_id",
+                new SimpleEntry<Object, Boolean>(recipientId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all query parameters
+        Map<String, Object> queryParameters = new HashMap<>();
+        queryParameters.put("page", page);
+        queryParameters.put("size", size);
+        queryParameters.put("status", status);
+        queryParameters.put("created_since", DateTimeHelper.toRfc8601DateTime(createdSince));
+        queryParameters.put("created_until", DateTimeHelper.toRfc8601DateTime(createdUntil));
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
+                null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getTransfers.
+     * @return An object of type ListTransferResponse
+     */
+    private ListTransferResponse handleGetTransfersResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        ListTransferResponse result = ApiHelper.deserialize(responseBody,
+                ListTransferResponse.class);
 
         return result;
     }

--- a/src/main/java/me/pagar/api/controllers/DefaultSubscriptionsController.java
+++ b/src/main/java/me/pagar/api/controllers/DefaultSubscriptionsController.java
@@ -141,386 +141,6 @@ public final class DefaultSubscriptionsController extends BaseController impleme
     }
 
     /**
-     * Updates the credit card from a subscription.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for updating a card
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionResponse updateSubscriptionCard(
-            final String subscriptionId,
-            final UpdateSubscriptionCardRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateSubscriptionCardRequest(subscriptionId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateSubscriptionCardResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateSubscriptionCard.
-     */
-    private HttpRequest buildUpdateSubscriptionCardRequest(
-            final String subscriptionId,
-            final UpdateSubscriptionCardRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/card");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateSubscriptionCard.
-     * @return An object of type GetSubscriptionResponse
-     */
-    private GetSubscriptionResponse handleUpdateSubscriptionCardResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Deletes a usage.
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  itemId  Required parameter: The subscription item id
-     * @param  usageId  Required parameter: The usage id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetUsageResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetUsageResponse deleteUsage(
-            final String subscriptionId,
-            final String itemId,
-            final String usageId,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildDeleteUsageRequest(subscriptionId, itemId, usageId,
-                idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleDeleteUsageResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for deleteUsage.
-     */
-    private HttpRequest buildDeleteUsageRequest(
-            final String subscriptionId,
-            final String itemId,
-            final String usageId,
-            final String idempotencyKey) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/items/{item_id}/usages/{usage_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        templateParameters.put("item_id",
-                new SimpleEntry<Object, Boolean>(itemId, true));
-        templateParameters.put("usage_id",
-                new SimpleEntry<Object, Boolean>(usageId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().delete(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for deleteUsage.
-     * @return An object of type GetUsageResponse
-     */
-    private GetUsageResponse handleDeleteUsageResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetUsageResponse result = ApiHelper.deserialize(responseBody,
-                GetUsageResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Creates a discount.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for creating a discount
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetDiscountResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetDiscountResponse createDiscount(
-            final String subscriptionId,
-            final CreateDiscountRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreateDiscountRequest(subscriptionId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCreateDiscountResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createDiscount.
-     */
-    private HttpRequest buildCreateDiscountRequest(
-            final String subscriptionId,
-            final CreateDiscountRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/discounts");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for createDiscount.
-     * @return An object of type GetDiscountResponse
-     */
-    private GetDiscountResponse handleCreateDiscountResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetDiscountResponse result = ApiHelper.deserialize(responseBody,
-                GetDiscountResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Create Usage.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  itemId  Required parameter: Item id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetUsageResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetUsageResponse createAnUsage(
-            final String subscriptionId,
-            final String itemId,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildCreateAnUsageRequest(subscriptionId, itemId, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleCreateAnUsageResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createAnUsage.
-     */
-    private HttpRequest buildCreateAnUsageRequest(
-            final String subscriptionId,
-            final String itemId,
-            final String idempotencyKey) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/items/{item_id}/usages");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        templateParameters.put("item_id",
-                new SimpleEntry<Object, Boolean>(itemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().post(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for createAnUsage.
-     * @return An object of type GetUsageResponse
-     */
-    private GetUsageResponse handleCreateAnUsageResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetUsageResponse result = ApiHelper.deserialize(responseBody,
-                GetUsageResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  request  Required parameter: Request for updating the end date of the subscription
-     *         current status
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public void updateCurrentCycleStatus(
-            final String subscriptionId,
-            final UpdateCurrentCycleStatusRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateCurrentCycleStatusRequest(subscriptionId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        handleUpdateCurrentCycleStatusResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateCurrentCycleStatus.
-     */
-    private HttpRequest buildUpdateCurrentCycleStatusRequest(
-            final String subscriptionId,
-            final UpdateCurrentCycleStatusRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/cycle-status");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateCurrentCycleStatus.
-     * @return An object of type void
-     */
-    private Void handleUpdateCurrentCycleStatusResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        return null;
-    }
-
-    /**
      * Deletes a discount.
      * @param  subscriptionId  Required parameter: Subscription id
      * @param  discountId  Required parameter: Discount Id
@@ -592,258 +212,6 @@ public final class DefaultSubscriptionsController extends BaseController impleme
         String responseBody = ((HttpStringResponse) response).getBody();
         GetDiscountResponse result = ApiHelper.deserialize(responseBody,
                 GetDiscountResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Get Subscription Items.
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @param  name  Optional parameter: The item name
-     * @param  code  Optional parameter: Identification code in the client system
-     * @param  status  Optional parameter: The item statis
-     * @param  description  Optional parameter: The item description
-     * @param  createdSince  Optional parameter: Filter for item's creation date start range
-     * @param  createdUntil  Optional parameter: Filter for item's creation date end range
-     * @return    Returns the ListSubscriptionItemsResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public ListSubscriptionItemsResponse getSubscriptionItems(
-            final String subscriptionId,
-            final Integer page,
-            final Integer size,
-            final String name,
-            final String code,
-            final String status,
-            final String description,
-            final String createdSince,
-            final String createdUntil) throws ApiException, IOException {
-        HttpRequest request = buildGetSubscriptionItemsRequest(subscriptionId, page, size, name,
-                code, status, description, createdSince, createdUntil);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetSubscriptionItemsResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getSubscriptionItems.
-     */
-    private HttpRequest buildGetSubscriptionItemsRequest(
-            final String subscriptionId,
-            final Integer page,
-            final Integer size,
-            final String name,
-            final String code,
-            final String status,
-            final String description,
-            final String createdSince,
-            final String createdUntil) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/items");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all query parameters
-        Map<String, Object> queryParameters = new HashMap<>();
-        queryParameters.put("page", page);
-        queryParameters.put("size", size);
-        queryParameters.put("name", name);
-        queryParameters.put("code", code);
-        queryParameters.put("status", status);
-        queryParameters.put("description", description);
-        queryParameters.put("created_since", createdSince);
-        queryParameters.put("created_until", createdUntil);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
-                null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getSubscriptionItems.
-     * @return An object of type ListSubscriptionItemsResponse
-     */
-    private ListSubscriptionItemsResponse handleGetSubscriptionItemsResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        ListSubscriptionItemsResponse result = ApiHelper.deserialize(responseBody,
-                ListSubscriptionItemsResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Updates the payment method from a subscription.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for updating the paymentmethod from a
-     *         subscription
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionResponse updateSubscriptionPaymentMethod(
-            final String subscriptionId,
-            final UpdateSubscriptionPaymentMethodRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateSubscriptionPaymentMethodRequest(subscriptionId,
-                request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateSubscriptionPaymentMethodResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateSubscriptionPaymentMethod.
-     */
-    private HttpRequest buildUpdateSubscriptionPaymentMethodRequest(
-            final String subscriptionId,
-            final UpdateSubscriptionPaymentMethodRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/payment-method");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateSubscriptionPaymentMethod.
-     * @return An object of type GetSubscriptionResponse
-     */
-    private GetSubscriptionResponse handleUpdateSubscriptionPaymentMethodResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Get Subscription Item.
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  itemId  Required parameter: Item id
-     * @return    Returns the GetSubscriptionItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionItemResponse getSubscriptionItem(
-            final String subscriptionId,
-            final String itemId) throws ApiException, IOException {
-        HttpRequest request = buildGetSubscriptionItemRequest(subscriptionId, itemId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetSubscriptionItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getSubscriptionItem.
-     */
-    private HttpRequest buildGetSubscriptionItemRequest(
-            final String subscriptionId,
-            final String itemId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/items/{item_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        templateParameters.put("item_id",
-                new SimpleEntry<Object, Boolean>(itemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getSubscriptionItem.
-     * @return An object of type GetSubscriptionItemResponse
-     */
-    private GetSubscriptionItemResponse handleGetSubscriptionItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionItemResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionItemResponse.class);
 
         return result;
     }
@@ -957,240 +325,6 @@ public final class DefaultSubscriptionsController extends BaseController impleme
         String responseBody = ((HttpStringResponse) response).getBody();
         ListSubscriptionsResponse result = ApiHelper.deserialize(responseBody,
                 ListSubscriptionsResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Cancels a subscription.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Optional parameter: Request for cancelling a subscription
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionResponse cancelSubscription(
-            final String subscriptionId,
-            final CreateCancelSubscriptionRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCancelSubscriptionRequest(subscriptionId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCancelSubscriptionResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for cancelSubscription.
-     */
-    private HttpRequest buildCancelSubscriptionRequest(
-            final String subscriptionId,
-            final CreateCancelSubscriptionRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().deleteBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for cancelSubscription.
-     * @return An object of type GetSubscriptionResponse
-     */
-    private GetSubscriptionResponse handleCancelSubscriptionResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Creates a increment.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for creating a increment
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetIncrementResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetIncrementResponse createIncrement(
-            final String subscriptionId,
-            final CreateIncrementRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreateIncrementRequest(subscriptionId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCreateIncrementResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createIncrement.
-     */
-    private HttpRequest buildCreateIncrementRequest(
-            final String subscriptionId,
-            final CreateIncrementRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/increments");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for createIncrement.
-     * @return An object of type GetIncrementResponse
-     */
-    private GetIncrementResponse handleCreateIncrementResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetIncrementResponse result = ApiHelper.deserialize(responseBody,
-                GetIncrementResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Creates a usage.
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  itemId  Required parameter: Item id
-     * @param  body  Required parameter: Request for creating a usage
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetUsageResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetUsageResponse createUsage(
-            final String subscriptionId,
-            final String itemId,
-            final CreateUsageRequest body,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildCreateUsageRequest(subscriptionId, itemId, body, idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleCreateUsageResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createUsage.
-     */
-    private HttpRequest buildCreateUsageRequest(
-            final String subscriptionId,
-            final String itemId,
-            final CreateUsageRequest body,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/items/{item_id}/usages");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        templateParameters.put("item_id",
-                new SimpleEntry<Object, Boolean>(itemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(body);
-        HttpRequest request = getClientInstance().postBody(queryBuilder, headers, null, bodyJson);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for createUsage.
-     * @return An object of type GetUsageResponse
-     */
-    private GetUsageResponse handleCreateUsageResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetUsageResponse result = ApiHelper.deserialize(responseBody,
-                GetUsageResponse.class);
 
         return result;
     }
@@ -1402,82 +536,6 @@ public final class DefaultSubscriptionsController extends BaseController impleme
     }
 
     /**
-     * @param  subscriptionId  Required parameter: Example:
-     * @param  request  Required parameter: Request for updating a subscription affiliation id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionResponse updateSubscriptionAffiliationId(
-            final String subscriptionId,
-            final UpdateSubscriptionAffiliationIdRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateSubscriptionAffiliationIdRequest(subscriptionId,
-                request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateSubscriptionAffiliationIdResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateSubscriptionAffiliationId.
-     */
-    private HttpRequest buildUpdateSubscriptionAffiliationIdRequest(
-            final String subscriptionId,
-            final UpdateSubscriptionAffiliationIdRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/gateway-affiliation-id");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateSubscriptionAffiliationId.
-     * @return An object of type GetSubscriptionResponse
-     */
-    private GetSubscriptionResponse handleUpdateSubscriptionAffiliationIdResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionResponse.class);
-
-        return result;
-    }
-
-    /**
      * Updates the metadata from a subscription.
      * @param  subscriptionId  Required parameter: The subscription id
      * @param  request  Required parameter: Request for updating the subscrption metadata
@@ -1631,39 +689,272 @@ public final class DefaultSubscriptionsController extends BaseController impleme
     }
 
     /**
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  page  Required parameter: Page number
-     * @param  size  Required parameter: Page size
-     * @return    Returns the ListCyclesResponse response from the API call
+     * Gets a subscription.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @return    Returns the GetSubscriptionResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public ListCyclesResponse getSubscriptionCycles(
-            final String subscriptionId,
-            final String page,
-            final String size) throws ApiException, IOException {
-        HttpRequest request = buildGetSubscriptionCyclesRequest(subscriptionId, page, size);
+    public GetSubscriptionResponse getSubscription(
+            final String subscriptionId) throws ApiException, IOException {
+        HttpRequest request = buildGetSubscriptionRequest(subscriptionId);
         authManagers.get("global").apply(request);
 
         HttpResponse response = getClientInstance().execute(request, false);
         HttpContext context = new HttpContext(request, response);
 
-        return handleGetSubscriptionCyclesResponse(context);
+        return handleGetSubscriptionResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for getSubscriptionCycles.
+     * Builds the HttpRequest object for getSubscription.
      */
-    private HttpRequest buildGetSubscriptionCyclesRequest(
-            final String subscriptionId,
-            final String page,
-            final String size) {
+    private HttpRequest buildGetSubscriptionRequest(
+            final String subscriptionId) {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/cycles");
+                + "/subscriptions/{subscription_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getSubscription.
+     * @return An object of type GetSubscriptionResponse
+     */
+    private GetSubscriptionResponse handleGetSubscriptionResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  subscriptionId  Required parameter: Example:
+     * @param  request  Required parameter: Request for updating the end date of the current
+     *         signature cycle
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionResponse updateLatestPeriodEndAt(
+            final String subscriptionId,
+            final UpdateCurrentCycleEndDateRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateLatestPeriodEndAtRequest(subscriptionId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateLatestPeriodEndAtResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateLatestPeriodEndAt.
+     */
+    private HttpRequest buildUpdateLatestPeriodEndAtRequest(
+            final String subscriptionId,
+            final UpdateCurrentCycleEndDateRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/periods/latest/end-at");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateLatestPeriodEndAt.
+     * @return An object of type GetSubscriptionResponse
+     */
+    private GetSubscriptionResponse handleUpdateLatestPeriodEndAtResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  request  Required parameter: Request for updating the end date of the subscription
+     *         current status
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public void updateCurrentCycleStatus(
+            final String subscriptionId,
+            final UpdateCurrentCycleStatusRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateCurrentCycleStatusRequest(subscriptionId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        handleUpdateCurrentCycleStatusResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateCurrentCycleStatus.
+     */
+    private HttpRequest buildUpdateCurrentCycleStatusRequest(
+            final String subscriptionId,
+            final UpdateCurrentCycleStatusRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/cycle-status");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateCurrentCycleStatus.
+     * @return An object of type void
+     */
+    private Void handleUpdateCurrentCycleStatusResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        return null;
+    }
+
+    /**
+     * Get Subscription Items.
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @param  name  Optional parameter: The item name
+     * @param  code  Optional parameter: Identification code in the client system
+     * @param  status  Optional parameter: The item statis
+     * @param  description  Optional parameter: The item description
+     * @param  createdSince  Optional parameter: Filter for item's creation date start range
+     * @param  createdUntil  Optional parameter: Filter for item's creation date end range
+     * @return    Returns the ListSubscriptionItemsResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public ListSubscriptionItemsResponse getSubscriptionItems(
+            final String subscriptionId,
+            final Integer page,
+            final Integer size,
+            final String name,
+            final String code,
+            final String status,
+            final String description,
+            final String createdSince,
+            final String createdUntil) throws ApiException, IOException {
+        HttpRequest request = buildGetSubscriptionItemsRequest(subscriptionId, page, size, name,
+                code, status, description, createdSince, createdUntil);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetSubscriptionItemsResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getSubscriptionItems.
+     */
+    private HttpRequest buildGetSubscriptionItemsRequest(
+            final String subscriptionId,
+            final Integer page,
+            final Integer size,
+            final String name,
+            final String code,
+            final String status,
+            final String description,
+            final String createdSince,
+            final String createdUntil) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/items");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
@@ -1675,6 +966,12 @@ public final class DefaultSubscriptionsController extends BaseController impleme
         Map<String, Object> queryParameters = new HashMap<>();
         queryParameters.put("page", page);
         queryParameters.put("size", size);
+        queryParameters.put("name", name);
+        queryParameters.put("code", code);
+        queryParameters.put("status", status);
+        queryParameters.put("description", description);
+        queryParameters.put("created_since", createdSince);
+        queryParameters.put("created_until", createdUntil);
 
         //load all headers for the outgoing API request
         Headers headers = new Headers();
@@ -1689,10 +986,10 @@ public final class DefaultSubscriptionsController extends BaseController impleme
     }
 
     /**
-     * Processes the response for getSubscriptionCycles.
-     * @return An object of type ListCyclesResponse
+     * Processes the response for getSubscriptionItems.
+     * @return An object of type ListSubscriptionItemsResponse
      */
-    private ListCyclesResponse handleGetSubscriptionCyclesResponse(
+    private ListSubscriptionItemsResponse handleGetSubscriptionItemsResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -1701,8 +998,155 @@ public final class DefaultSubscriptionsController extends BaseController impleme
 
         //extract result from the http response
         String responseBody = ((HttpStringResponse) response).getBody();
-        ListCyclesResponse result = ApiHelper.deserialize(responseBody,
-                ListCyclesResponse.class);
+        ListSubscriptionItemsResponse result = ApiHelper.deserialize(responseBody,
+                ListSubscriptionItemsResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Get Subscription Item.
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  itemId  Required parameter: Item id
+     * @return    Returns the GetSubscriptionItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionItemResponse getSubscriptionItem(
+            final String subscriptionId,
+            final String itemId) throws ApiException, IOException {
+        HttpRequest request = buildGetSubscriptionItemRequest(subscriptionId, itemId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetSubscriptionItemResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getSubscriptionItem.
+     */
+    private HttpRequest buildGetSubscriptionItemRequest(
+            final String subscriptionId,
+            final String itemId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/items/{item_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        templateParameters.put("item_id",
+                new SimpleEntry<Object, Boolean>(itemId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getSubscriptionItem.
+     * @return An object of type GetSubscriptionItemResponse
+     */
+    private GetSubscriptionItemResponse handleGetSubscriptionItemResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionItemResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionItemResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  subscriptionId  Required parameter: Example:
+     * @param  request  Required parameter: Request for updating a subscription affiliation id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionResponse updateSubscriptionAffiliationId(
+            final String subscriptionId,
+            final UpdateSubscriptionAffiliationIdRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateSubscriptionAffiliationIdRequest(subscriptionId,
+                request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateSubscriptionAffiliationIdResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateSubscriptionAffiliationId.
+     */
+    private HttpRequest buildUpdateSubscriptionAffiliationIdRequest(
+            final String subscriptionId,
+            final UpdateSubscriptionAffiliationIdRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/gateway-affiliation-id");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateSubscriptionAffiliationId.
+     * @return An object of type GetSubscriptionResponse
+     */
+    private GetSubscriptionResponse handleUpdateSubscriptionAffiliationIdResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionResponse.class);
 
         return result;
     }
@@ -1785,41 +1229,300 @@ public final class DefaultSubscriptionsController extends BaseController impleme
     }
 
     /**
-     * Updates the billing date from a subscription.
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  request  Required parameter: Request for updating the subscription billing date
+     * Updates a subscription item.
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  itemId  Required parameter: Item id
+     * @param  body  Required parameter: Request for updating a subscription item
      * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @return    Returns the GetSubscriptionItemResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    public GetSubscriptionResponse updateSubscriptionBillingDate(
+    public GetSubscriptionItemResponse updateSubscriptionItem(
             final String subscriptionId,
-            final UpdateSubscriptionBillingDateRequest request,
+            final String itemId,
+            final UpdateSubscriptionItemRequest body,
             final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateSubscriptionBillingDateRequest(subscriptionId,
-                request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
+        HttpRequest request = buildUpdateSubscriptionItemRequest(subscriptionId, itemId, body,
+                idempotencyKey);
+        authManagers.get("global").apply(request);
 
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
 
-        return handleUpdateSubscriptionBillingDateResponse(context);
+        return handleUpdateSubscriptionItemResponse(context);
     }
 
     /**
-     * Builds the HttpRequest object for updateSubscriptionBillingDate.
+     * Builds the HttpRequest object for updateSubscriptionItem.
      */
-    private HttpRequest buildUpdateSubscriptionBillingDateRequest(
+    private HttpRequest buildUpdateSubscriptionItemRequest(
             final String subscriptionId,
-            final UpdateSubscriptionBillingDateRequest request,
+            final String itemId,
+            final UpdateSubscriptionItemRequest body,
             final String idempotencyKey) throws JsonProcessingException {
         //the base uri for api requests
         String baseUri = config.getBaseUri();
 
         //prepare query string for API call
         final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/billing-date");
+                + "/subscriptions/{subscription_id}/items/{item_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        templateParameters.put("item_id",
+                new SimpleEntry<Object, Boolean>(itemId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(body);
+        HttpRequest request = getClientInstance().putBody(queryBuilder, headers, null, bodyJson);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for updateSubscriptionItem.
+     * @return An object of type GetSubscriptionItemResponse
+     */
+    private GetSubscriptionItemResponse handleUpdateSubscriptionItemResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionItemResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionItemResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a new Subscription item.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for creating a subscription item
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionItemResponse createSubscriptionItem(
+            final String subscriptionId,
+            final CreateSubscriptionItemRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreateSubscriptionItemRequest(subscriptionId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCreateSubscriptionItemResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createSubscriptionItem.
+     */
+    private HttpRequest buildCreateSubscriptionItemRequest(
+            final String subscriptionId,
+            final CreateSubscriptionItemRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/items");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for createSubscriptionItem.
+     * @return An object of type GetSubscriptionItemResponse
+     */
+    private GetSubscriptionItemResponse handleCreateSubscriptionItemResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionItemResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionItemResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Lists all usages from a subscription item.
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  itemId  Required parameter: The subscription item id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @param  code  Optional parameter: Identification code in the client system
+     * @param  group  Optional parameter: Identification group in the client system
+     * @param  usedSince  Optional parameter: Example:
+     * @param  usedUntil  Optional parameter: Example:
+     * @return    Returns the ListUsagesResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public ListUsagesResponse getUsages(
+            final String subscriptionId,
+            final String itemId,
+            final Integer page,
+            final Integer size,
+            final String code,
+            final String group,
+            final LocalDateTime usedSince,
+            final LocalDateTime usedUntil) throws ApiException, IOException {
+        HttpRequest request = buildGetUsagesRequest(subscriptionId, itemId, page, size, code, group,
+                usedSince, usedUntil);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetUsagesResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getUsages.
+     */
+    private HttpRequest buildGetUsagesRequest(
+            final String subscriptionId,
+            final String itemId,
+            final Integer page,
+            final Integer size,
+            final String code,
+            final String group,
+            final LocalDateTime usedSince,
+            final LocalDateTime usedUntil) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/items/{item_id}/usages");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        templateParameters.put("item_id",
+                new SimpleEntry<Object, Boolean>(itemId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all query parameters
+        Map<String, Object> queryParameters = new HashMap<>();
+        queryParameters.put("page", page);
+        queryParameters.put("size", size);
+        queryParameters.put("code", code);
+        queryParameters.put("group", group);
+        queryParameters.put("used_since", DateTimeHelper.toRfc8601DateTime(usedSince));
+        queryParameters.put("used_until", DateTimeHelper.toRfc8601DateTime(usedUntil));
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
+                null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getUsages.
+     * @return An object of type ListUsagesResponse
+     */
+    private ListUsagesResponse handleGetUsagesResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        ListUsagesResponse result = ApiHelper.deserialize(responseBody,
+                ListUsagesResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Atualização do valor mínimo da assinatura.
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  request  Required parameter: Request da requisição com o valor mínimo que será
+     *         configurado
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionResponse updateSubscriptionMiniumPrice(
+            final String subscriptionId,
+            final UpdateSubscriptionMinimumPriceRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateSubscriptionMiniumPriceRequest(subscriptionId,
+                request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateSubscriptionMiniumPriceResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateSubscriptionMiniumPrice.
+     */
+    private HttpRequest buildUpdateSubscriptionMiniumPriceRequest(
+            final String subscriptionId,
+            final UpdateSubscriptionMinimumPriceRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/minimum_price");
 
         //process template parameters
         Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
@@ -1843,10 +1546,232 @@ public final class DefaultSubscriptionsController extends BaseController impleme
     }
 
     /**
-     * Processes the response for updateSubscriptionBillingDate.
+     * Processes the response for updateSubscriptionMiniumPrice.
      * @return An object of type GetSubscriptionResponse
      */
-    private GetSubscriptionResponse handleUpdateSubscriptionBillingDateResponse(
+    private GetSubscriptionResponse handleUpdateSubscriptionMiniumPriceResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  cycleId  Required parameter: Example:
+     * @return    Returns the GetPeriodResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetPeriodResponse getSubscriptionCycleById(
+            final String subscriptionId,
+            final String cycleId) throws ApiException, IOException {
+        HttpRequest request = buildGetSubscriptionCycleByIdRequest(subscriptionId, cycleId);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetSubscriptionCycleByIdResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getSubscriptionCycleById.
+     */
+    private HttpRequest buildGetSubscriptionCycleByIdRequest(
+            final String subscriptionId,
+            final String cycleId) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/cycles/{cycleId}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        templateParameters.put("cycleId",
+                new SimpleEntry<Object, Boolean>(cycleId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getSubscriptionCycleById.
+     * @return An object of type GetPeriodResponse
+     */
+    private GetPeriodResponse handleGetSubscriptionCycleByIdResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetPeriodResponse result = ApiHelper.deserialize(responseBody,
+                GetPeriodResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Create Usage.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  itemId  Required parameter: Item id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetUsageResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetUsageResponse createAnUsage(
+            final String subscriptionId,
+            final String itemId,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildCreateAnUsageRequest(subscriptionId, itemId, idempotencyKey);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleCreateAnUsageResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createAnUsage.
+     */
+    private HttpRequest buildCreateAnUsageRequest(
+            final String subscriptionId,
+            final String itemId,
+            final String idempotencyKey) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/items/{item_id}/usages");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        templateParameters.put("item_id",
+                new SimpleEntry<Object, Boolean>(itemId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().post(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for createAnUsage.
+     * @return An object of type GetUsageResponse
+     */
+    private GetUsageResponse handleCreateAnUsageResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetUsageResponse result = ApiHelper.deserialize(responseBody,
+                GetUsageResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Cancels a subscription.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Optional parameter: Request for cancelling a subscription
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionResponse cancelSubscription(
+            final String subscriptionId,
+            final CreateCancelSubscriptionRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCancelSubscriptionRequest(subscriptionId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCancelSubscriptionResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for cancelSubscription.
+     */
+    private HttpRequest buildCancelSubscriptionRequest(
+            final String subscriptionId,
+            final CreateCancelSubscriptionRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().deleteBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for cancelSubscription.
+     * @return An object of type GetSubscriptionResponse
+     */
+    private GetSubscriptionResponse handleCancelSubscriptionResponse(
             HttpContext context) throws ApiException, IOException {
         HttpResponse response = context.getResponse();
 
@@ -2092,6 +2017,630 @@ public final class DefaultSubscriptionsController extends BaseController impleme
     }
 
     /**
+     * Updates the credit card from a subscription.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for updating a card
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionResponse updateSubscriptionCard(
+            final String subscriptionId,
+            final UpdateSubscriptionCardRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateSubscriptionCardRequest(subscriptionId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateSubscriptionCardResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateSubscriptionCard.
+     */
+    private HttpRequest buildUpdateSubscriptionCardRequest(
+            final String subscriptionId,
+            final UpdateSubscriptionCardRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/card");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateSubscriptionCard.
+     * @return An object of type GetSubscriptionResponse
+     */
+    private GetSubscriptionResponse handleUpdateSubscriptionCardResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Deletes a usage.
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  itemId  Required parameter: The subscription item id
+     * @param  usageId  Required parameter: The usage id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetUsageResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetUsageResponse deleteUsage(
+            final String subscriptionId,
+            final String itemId,
+            final String usageId,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildDeleteUsageRequest(subscriptionId, itemId, usageId,
+                idempotencyKey);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleDeleteUsageResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for deleteUsage.
+     */
+    private HttpRequest buildDeleteUsageRequest(
+            final String subscriptionId,
+            final String itemId,
+            final String usageId,
+            final String idempotencyKey) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/items/{item_id}/usages/{usage_id}");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        templateParameters.put("item_id",
+                new SimpleEntry<Object, Boolean>(itemId, true));
+        templateParameters.put("usage_id",
+                new SimpleEntry<Object, Boolean>(usageId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().delete(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for deleteUsage.
+     * @return An object of type GetUsageResponse
+     */
+    private GetUsageResponse handleDeleteUsageResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetUsageResponse result = ApiHelper.deserialize(responseBody,
+                GetUsageResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a discount.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for creating a discount
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetDiscountResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetDiscountResponse createDiscount(
+            final String subscriptionId,
+            final CreateDiscountRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreateDiscountRequest(subscriptionId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCreateDiscountResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createDiscount.
+     */
+    private HttpRequest buildCreateDiscountRequest(
+            final String subscriptionId,
+            final CreateDiscountRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/discounts");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for createDiscount.
+     * @return An object of type GetDiscountResponse
+     */
+    private GetDiscountResponse handleCreateDiscountResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetDiscountResponse result = ApiHelper.deserialize(responseBody,
+                GetDiscountResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Updates the payment method from a subscription.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for updating the paymentmethod from a
+     *         subscription
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionResponse updateSubscriptionPaymentMethod(
+            final String subscriptionId,
+            final UpdateSubscriptionPaymentMethodRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateSubscriptionPaymentMethodRequest(subscriptionId,
+                request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateSubscriptionPaymentMethodResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateSubscriptionPaymentMethod.
+     */
+    private HttpRequest buildUpdateSubscriptionPaymentMethodRequest(
+            final String subscriptionId,
+            final UpdateSubscriptionPaymentMethodRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/payment-method");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateSubscriptionPaymentMethod.
+     * @return An object of type GetSubscriptionResponse
+     */
+    private GetSubscriptionResponse handleUpdateSubscriptionPaymentMethodResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a increment.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for creating a increment
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetIncrementResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetIncrementResponse createIncrement(
+            final String subscriptionId,
+            final CreateIncrementRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildCreateIncrementRequest(subscriptionId, request,
+                idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleCreateIncrementResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createIncrement.
+     */
+    private HttpRequest buildCreateIncrementRequest(
+            final String subscriptionId,
+            final CreateIncrementRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/increments");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for createIncrement.
+     * @return An object of type GetIncrementResponse
+     */
+    private GetIncrementResponse handleCreateIncrementResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetIncrementResponse result = ApiHelper.deserialize(responseBody,
+                GetIncrementResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a usage.
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  itemId  Required parameter: Item id
+     * @param  body  Required parameter: Request for creating a usage
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetUsageResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetUsageResponse createUsage(
+            final String subscriptionId,
+            final String itemId,
+            final CreateUsageRequest body,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest request = buildCreateUsageRequest(subscriptionId, itemId, body, idempotencyKey);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleCreateUsageResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for createUsage.
+     */
+    private HttpRequest buildCreateUsageRequest(
+            final String subscriptionId,
+            final String itemId,
+            final CreateUsageRequest body,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/items/{item_id}/usages");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        templateParameters.put("item_id",
+                new SimpleEntry<Object, Boolean>(itemId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(body);
+        HttpRequest request = getClientInstance().postBody(queryBuilder, headers, null, bodyJson);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for createUsage.
+     * @return An object of type GetUsageResponse
+     */
+    private GetUsageResponse handleCreateUsageResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetUsageResponse result = ApiHelper.deserialize(responseBody,
+                GetUsageResponse.class);
+
+        return result;
+    }
+
+    /**
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  page  Required parameter: Page number
+     * @param  size  Required parameter: Page size
+     * @return    Returns the ListCyclesResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public ListCyclesResponse getSubscriptionCycles(
+            final String subscriptionId,
+            final String page,
+            final String size) throws ApiException, IOException {
+        HttpRequest request = buildGetSubscriptionCyclesRequest(subscriptionId, page, size);
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetSubscriptionCyclesResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getSubscriptionCycles.
+     */
+    private HttpRequest buildGetSubscriptionCyclesRequest(
+            final String subscriptionId,
+            final String page,
+            final String size) {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/cycles");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all query parameters
+        Map<String, Object> queryParameters = new HashMap<>();
+        queryParameters.put("page", page);
+        queryParameters.put("size", size);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
+                null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getSubscriptionCycles.
+     * @return An object of type ListCyclesResponse
+     */
+    private ListCyclesResponse handleGetSubscriptionCyclesResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        ListCyclesResponse result = ApiHelper.deserialize(responseBody,
+                ListCyclesResponse.class);
+
+        return result;
+    }
+
+    /**
+     * Updates the billing date from a subscription.
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  request  Required parameter: Request for updating the subscription billing date
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public GetSubscriptionResponse updateSubscriptionBillingDate(
+            final String subscriptionId,
+            final UpdateSubscriptionBillingDateRequest request,
+            final String idempotencyKey) throws ApiException, IOException {
+        HttpRequest internalRequest = buildUpdateSubscriptionBillingDateRequest(subscriptionId,
+                request, idempotencyKey);
+        authManagers.get("global").apply(internalRequest);
+
+        HttpResponse response = getClientInstance().execute(internalRequest, false);
+        HttpContext context = new HttpContext(internalRequest, response);
+
+        return handleUpdateSubscriptionBillingDateResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for updateSubscriptionBillingDate.
+     */
+    private HttpRequest buildUpdateSubscriptionBillingDateRequest(
+            final String subscriptionId,
+            final UpdateSubscriptionBillingDateRequest request,
+            final String idempotencyKey) throws JsonProcessingException {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/subscriptions/{subscription_id}/billing-date");
+
+        //process template parameters
+        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
+        templateParameters.put("subscription_id",
+                new SimpleEntry<Object, Boolean>(subscriptionId, true));
+        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("idempotency-key", idempotencyKey);
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+        headers.add("content-type", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        String bodyJson = ApiHelper.serialize(request);
+        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
+                bodyJson);
+
+        return internalRequest;
+    }
+
+    /**
+     * Processes the response for updateSubscriptionBillingDate.
+     * @return An object of type GetSubscriptionResponse
+     */
+    private GetSubscriptionResponse handleUpdateSubscriptionBillingDateResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
+                GetSubscriptionResponse.class);
+
+        return result;
+    }
+
+    /**
      * Updates the start at date from a subscription.
      * @param  subscriptionId  Required parameter: The subscription id
      * @param  request  Required parameter: Request for updating the subscription start date
@@ -2164,555 +2713,6 @@ public final class DefaultSubscriptionsController extends BaseController impleme
         String responseBody = ((HttpStringResponse) response).getBody();
         GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
                 GetSubscriptionResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Updates a subscription item.
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  itemId  Required parameter: Item id
-     * @param  body  Required parameter: Request for updating a subscription item
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionItemResponse updateSubscriptionItem(
-            final String subscriptionId,
-            final String itemId,
-            final UpdateSubscriptionItemRequest body,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest request = buildUpdateSubscriptionItemRequest(subscriptionId, itemId, body,
-                idempotencyKey);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleUpdateSubscriptionItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateSubscriptionItem.
-     */
-    private HttpRequest buildUpdateSubscriptionItemRequest(
-            final String subscriptionId,
-            final String itemId,
-            final UpdateSubscriptionItemRequest body,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/items/{item_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        templateParameters.put("item_id",
-                new SimpleEntry<Object, Boolean>(itemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(body);
-        HttpRequest request = getClientInstance().putBody(queryBuilder, headers, null, bodyJson);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for updateSubscriptionItem.
-     * @return An object of type GetSubscriptionItemResponse
-     */
-    private GetSubscriptionItemResponse handleUpdateSubscriptionItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionItemResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionItemResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Creates a new Subscription item.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for creating a subscription item
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionItemResponse createSubscriptionItem(
-            final String subscriptionId,
-            final CreateSubscriptionItemRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildCreateSubscriptionItemRequest(subscriptionId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleCreateSubscriptionItemResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for createSubscriptionItem.
-     */
-    private HttpRequest buildCreateSubscriptionItemRequest(
-            final String subscriptionId,
-            final CreateSubscriptionItemRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/items");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().postBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for createSubscriptionItem.
-     * @return An object of type GetSubscriptionItemResponse
-     */
-    private GetSubscriptionItemResponse handleCreateSubscriptionItemResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionItemResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionItemResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Gets a subscription.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionResponse getSubscription(
-            final String subscriptionId) throws ApiException, IOException {
-        HttpRequest request = buildGetSubscriptionRequest(subscriptionId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetSubscriptionResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getSubscription.
-     */
-    private HttpRequest buildGetSubscriptionRequest(
-            final String subscriptionId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getSubscription.
-     * @return An object of type GetSubscriptionResponse
-     */
-    private GetSubscriptionResponse handleGetSubscriptionResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Lists all usages from a subscription item.
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  itemId  Required parameter: The subscription item id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @param  code  Optional parameter: Identification code in the client system
-     * @param  group  Optional parameter: Identification group in the client system
-     * @param  usedSince  Optional parameter: Example:
-     * @param  usedUntil  Optional parameter: Example:
-     * @return    Returns the ListUsagesResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public ListUsagesResponse getUsages(
-            final String subscriptionId,
-            final String itemId,
-            final Integer page,
-            final Integer size,
-            final String code,
-            final String group,
-            final LocalDateTime usedSince,
-            final LocalDateTime usedUntil) throws ApiException, IOException {
-        HttpRequest request = buildGetUsagesRequest(subscriptionId, itemId, page, size, code, group,
-                usedSince, usedUntil);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetUsagesResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getUsages.
-     */
-    private HttpRequest buildGetUsagesRequest(
-            final String subscriptionId,
-            final String itemId,
-            final Integer page,
-            final Integer size,
-            final String code,
-            final String group,
-            final LocalDateTime usedSince,
-            final LocalDateTime usedUntil) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/items/{item_id}/usages");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        templateParameters.put("item_id",
-                new SimpleEntry<Object, Boolean>(itemId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all query parameters
-        Map<String, Object> queryParameters = new HashMap<>();
-        queryParameters.put("page", page);
-        queryParameters.put("size", size);
-        queryParameters.put("code", code);
-        queryParameters.put("group", group);
-        queryParameters.put("used_since", DateTimeHelper.toRfc8601DateTime(usedSince));
-        queryParameters.put("used_until", DateTimeHelper.toRfc8601DateTime(usedUntil));
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, queryParameters,
-                null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getUsages.
-     * @return An object of type ListUsagesResponse
-     */
-    private ListUsagesResponse handleGetUsagesResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        ListUsagesResponse result = ApiHelper.deserialize(responseBody,
-                ListUsagesResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  subscriptionId  Required parameter: Example:
-     * @param  request  Required parameter: Request for updating the end date of the current
-     *         signature cycle
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionResponse updateLatestPeriodEndAt(
-            final String subscriptionId,
-            final UpdateCurrentCycleEndDateRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateLatestPeriodEndAtRequest(subscriptionId, request,
-                idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateLatestPeriodEndAtResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateLatestPeriodEndAt.
-     */
-    private HttpRequest buildUpdateLatestPeriodEndAtRequest(
-            final String subscriptionId,
-            final UpdateCurrentCycleEndDateRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/periods/latest/end-at");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateLatestPeriodEndAt.
-     * @return An object of type GetSubscriptionResponse
-     */
-    private GetSubscriptionResponse handleUpdateLatestPeriodEndAtResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionResponse.class);
-
-        return result;
-    }
-
-    /**
-     * Atualização do valor mínimo da assinatura.
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  request  Required parameter: Request da requisição com o valor mínimo que será
-     *         configurado
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetSubscriptionResponse updateSubscriptionMiniumPrice(
-            final String subscriptionId,
-            final UpdateSubscriptionMinimumPriceRequest request,
-            final String idempotencyKey) throws ApiException, IOException {
-        HttpRequest internalRequest = buildUpdateSubscriptionMiniumPriceRequest(subscriptionId,
-                request, idempotencyKey);
-        authManagers.get("global").apply(internalRequest);
-
-        HttpResponse response = getClientInstance().execute(internalRequest, false);
-        HttpContext context = new HttpContext(internalRequest, response);
-
-        return handleUpdateSubscriptionMiniumPriceResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for updateSubscriptionMiniumPrice.
-     */
-    private HttpRequest buildUpdateSubscriptionMiniumPriceRequest(
-            final String subscriptionId,
-            final UpdateSubscriptionMinimumPriceRequest request,
-            final String idempotencyKey) throws JsonProcessingException {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/minimum_price");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("idempotency-key", idempotencyKey);
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-        headers.add("content-type", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        String bodyJson = ApiHelper.serialize(request);
-        HttpRequest internalRequest = getClientInstance().patchBody(queryBuilder, headers, null,
-                bodyJson);
-
-        return internalRequest;
-    }
-
-    /**
-     * Processes the response for updateSubscriptionMiniumPrice.
-     * @return An object of type GetSubscriptionResponse
-     */
-    private GetSubscriptionResponse handleUpdateSubscriptionMiniumPriceResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetSubscriptionResponse result = ApiHelper.deserialize(responseBody,
-                GetSubscriptionResponse.class);
-
-        return result;
-    }
-
-    /**
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  cycleId  Required parameter: Example:
-     * @return    Returns the GetPeriodResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public GetPeriodResponse getSubscriptionCycleById(
-            final String subscriptionId,
-            final String cycleId) throws ApiException, IOException {
-        HttpRequest request = buildGetSubscriptionCycleByIdRequest(subscriptionId, cycleId);
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetSubscriptionCycleByIdResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getSubscriptionCycleById.
-     */
-    private HttpRequest buildGetSubscriptionCycleByIdRequest(
-            final String subscriptionId,
-            final String cycleId) {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/subscriptions/{subscription_id}/cycles/{cycleId}");
-
-        //process template parameters
-        Map<String, SimpleEntry<Object, Boolean>> templateParameters = new HashMap<>();
-        templateParameters.put("subscription_id",
-                new SimpleEntry<Object, Boolean>(subscriptionId, true));
-        templateParameters.put("cycleId",
-                new SimpleEntry<Object, Boolean>(cycleId, true));
-        ApiHelper.appendUrlWithTemplateParameters(queryBuilder, templateParameters);
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getSubscriptionCycleById.
-     * @return An object of type GetPeriodResponse
-     */
-    private GetPeriodResponse handleGetSubscriptionCycleByIdResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        GetPeriodResponse result = ApiHelper.deserialize(responseBody,
-                GetPeriodResponse.class);
 
         return result;
     }

--- a/src/main/java/me/pagar/api/controllers/DefaultTransfersController.java
+++ b/src/main/java/me/pagar/api/controllers/DefaultTransfersController.java
@@ -43,6 +43,63 @@ public final class DefaultTransfersController extends BaseController implements 
 
 
     /**
+     * Gets all transfers.
+     * @return    Returns the ListTransfers response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    public ListTransfers getTransfers() throws ApiException, IOException {
+        HttpRequest request = buildGetTransfersRequest();
+        authManagers.get("global").apply(request);
+
+        HttpResponse response = getClientInstance().execute(request, false);
+        HttpContext context = new HttpContext(request, response);
+
+        return handleGetTransfersResponse(context);
+    }
+
+    /**
+     * Builds the HttpRequest object for getTransfers.
+     */
+    private HttpRequest buildGetTransfersRequest() {
+        //the base uri for api requests
+        String baseUri = config.getBaseUri();
+
+        //prepare query string for API call
+        final StringBuilder queryBuilder = new StringBuilder(baseUri
+                + "/transfers");
+
+        //load all headers for the outgoing API request
+        Headers headers = new Headers();
+        headers.add("user-agent", BaseController.userAgent);
+        headers.add("accept", "application/json");
+
+        //prepare and invoke the API call request to fetch the response
+        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
+
+        return request;
+    }
+
+    /**
+     * Processes the response for getTransfers.
+     * @return An object of type ListTransfers
+     */
+    private ListTransfers handleGetTransfersResponse(
+            HttpContext context) throws ApiException, IOException {
+        HttpResponse response = context.getResponse();
+
+        //handle errors defined at the API level
+        validateResponse(response, context);
+
+        //extract result from the http response
+        String responseBody = ((HttpStringResponse) response).getBody();
+        ListTransfers result = ApiHelper.deserialize(responseBody,
+                ListTransfers.class);
+
+        return result;
+    }
+
+    /**
      * @param  transferId  Required parameter: Example:
      * @return    Returns the GetTransfer response from the API call
      * @throws    ApiException    Represents error response from the server.
@@ -165,63 +222,6 @@ public final class DefaultTransfersController extends BaseController implements 
         String responseBody = ((HttpStringResponse) response).getBody();
         GetTransfer result = ApiHelper.deserialize(responseBody,
                 GetTransfer.class);
-
-        return result;
-    }
-
-    /**
-     * Gets all transfers.
-     * @return    Returns the ListTransfers response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    public ListTransfers getTransfers() throws ApiException, IOException {
-        HttpRequest request = buildGetTransfersRequest();
-        authManagers.get("global").apply(request);
-
-        HttpResponse response = getClientInstance().execute(request, false);
-        HttpContext context = new HttpContext(request, response);
-
-        return handleGetTransfersResponse(context);
-    }
-
-    /**
-     * Builds the HttpRequest object for getTransfers.
-     */
-    private HttpRequest buildGetTransfersRequest() {
-        //the base uri for api requests
-        String baseUri = config.getBaseUri();
-
-        //prepare query string for API call
-        final StringBuilder queryBuilder = new StringBuilder(baseUri
-                + "/transfers");
-
-        //load all headers for the outgoing API request
-        Headers headers = new Headers();
-        headers.add("user-agent", BaseController.userAgent);
-        headers.add("accept", "application/json");
-
-        //prepare and invoke the API call request to fetch the response
-        HttpRequest request = getClientInstance().get(queryBuilder, headers, null, null);
-
-        return request;
-    }
-
-    /**
-     * Processes the response for getTransfers.
-     * @return An object of type ListTransfers
-     */
-    private ListTransfers handleGetTransfersResponse(
-            HttpContext context) throws ApiException, IOException {
-        HttpResponse response = context.getResponse();
-
-        //handle errors defined at the API level
-        validateResponse(response, context);
-
-        //extract result from the http response
-        String responseBody = ((HttpStringResponse) response).getBody();
-        ListTransfers result = ApiHelper.deserialize(responseBody,
-                ListTransfers.class);
 
         return result;
     }

--- a/src/main/java/me/pagar/api/controllers/InvoicesController.java
+++ b/src/main/java/me/pagar/api/controllers/InvoicesController.java
@@ -21,41 +21,6 @@ import me.pagar.api.models.UpdateMetadataRequest;
  */
 public interface InvoicesController {
     /**
-     * Updates the metadata from an invoice.
-     * @param  invoiceId  Required parameter: The invoice id
-     * @param  request  Required parameter: Request for updating the invoice metadata
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetInvoiceResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetInvoiceResponse updateInvoiceMetadata(
-            final String invoiceId,
-            final UpdateMetadataRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @return    Returns the GetInvoiceResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetInvoiceResponse getPartialInvoice(
-            final String subscriptionId) throws ApiException, IOException;
-
-    /**
-     * Cancels an invoice.
-     * @param  invoiceId  Required parameter: Invoice id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetInvoiceResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetInvoiceResponse cancelInvoice(
-            final String invoiceId,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
      * Create an Invoice.
      * @param  subscriptionId  Required parameter: Subscription Id
      * @param  cycleId  Required parameter: Cycle Id
@@ -102,14 +67,39 @@ public interface InvoicesController {
             final String customerDocument) throws ApiException, IOException;
 
     /**
-     * Gets an invoice.
-     * @param  invoiceId  Required parameter: Invoice Id
+     * Cancels an invoice.
+     * @param  invoiceId  Required parameter: Invoice id
+     * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetInvoiceResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetInvoiceResponse getInvoice(
-            final String invoiceId) throws ApiException, IOException;
+    GetInvoiceResponse cancelInvoice(
+            final String invoiceId,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Updates the metadata from an invoice.
+     * @param  invoiceId  Required parameter: The invoice id
+     * @param  request  Required parameter: Request for updating the invoice metadata
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetInvoiceResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetInvoiceResponse updateInvoiceMetadata(
+            final String invoiceId,
+            final UpdateMetadataRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @return    Returns the GetInvoiceResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetInvoiceResponse getPartialInvoice(
+            final String subscriptionId) throws ApiException, IOException;
 
     /**
      * Updates the status from an invoice.
@@ -124,5 +114,15 @@ public interface InvoicesController {
             final String invoiceId,
             final UpdateInvoiceStatusRequest request,
             final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Gets an invoice.
+     * @param  invoiceId  Required parameter: Invoice Id
+     * @return    Returns the GetInvoiceResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetInvoiceResponse getInvoice(
+            final String invoiceId) throws ApiException, IOException;
 
 }

--- a/src/main/java/me/pagar/api/controllers/OrdersController.java
+++ b/src/main/java/me/pagar/api/controllers/OrdersController.java
@@ -48,41 +48,23 @@ public interface OrdersController {
     /**
      * @param  orderId  Required parameter: Order Id
      * @param  itemId  Required parameter: Item Id
-     * @param  request  Required parameter: Item Model
-     * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetOrderItemResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetOrderItemResponse updateOrderItem(
+    GetOrderItemResponse getOrderItem(
             final String orderId,
-            final String itemId,
-            final UpdateOrderItemRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
+            final String itemId) throws ApiException, IOException;
 
     /**
-     * @param  orderId  Required parameter: Order Id
-     * @param  idempotencyKey  Optional parameter: Example:
+     * Gets an order.
+     * @param  orderId  Required parameter: Order id
      * @return    Returns the GetOrderResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetOrderResponse deleteAllOrderItems(
-            final String orderId,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * @param  orderId  Required parameter: Order Id
-     * @param  itemId  Required parameter: Item Id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetOrderItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetOrderItemResponse deleteOrderItem(
-            final String orderId,
-            final String itemId,
-            final String idempotencyKey) throws ApiException, IOException;
+    GetOrderResponse getOrder(
+            final String orderId) throws ApiException, IOException;
 
     /**
      * @param  id  Required parameter: Order Id
@@ -111,27 +93,29 @@ public interface OrdersController {
 
     /**
      * @param  orderId  Required parameter: Order Id
-     * @param  request  Required parameter: Order Item Model
+     * @param  itemId  Required parameter: Item Id
+     * @param  request  Required parameter: Item Model
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetOrderItemResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetOrderItemResponse createOrderItem(
+    GetOrderItemResponse updateOrderItem(
             final String orderId,
-            final CreateOrderItemRequest request,
+            final String itemId,
+            final UpdateOrderItemRequest request,
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
      * @param  orderId  Required parameter: Order Id
-     * @param  itemId  Required parameter: Item Id
-     * @return    Returns the GetOrderItemResponse response from the API call
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetOrderResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetOrderItemResponse getOrderItem(
+    GetOrderResponse deleteAllOrderItems(
             final String orderId,
-            final String itemId) throws ApiException, IOException;
+            final String idempotencyKey) throws ApiException, IOException;
 
     /**
      * Updates the metadata from an order.
@@ -148,13 +132,29 @@ public interface OrdersController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
-     * Gets an order.
-     * @param  orderId  Required parameter: Order id
-     * @return    Returns the GetOrderResponse response from the API call
+     * @param  orderId  Required parameter: Order Id
+     * @param  itemId  Required parameter: Item Id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetOrderItemResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetOrderResponse getOrder(
-            final String orderId) throws ApiException, IOException;
+    GetOrderItemResponse deleteOrderItem(
+            final String orderId,
+            final String itemId,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * @param  orderId  Required parameter: Order Id
+     * @param  request  Required parameter: Order Item Model
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetOrderItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetOrderItemResponse createOrderItem(
+            final String orderId,
+            final CreateOrderItemRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
 
 }

--- a/src/main/java/me/pagar/api/controllers/PlansController.java
+++ b/src/main/java/me/pagar/api/controllers/PlansController.java
@@ -34,15 +34,17 @@ public interface PlansController {
             final String planId) throws ApiException, IOException;
 
     /**
-     * Deletes a plan.
+     * Updates a plan.
      * @param  planId  Required parameter: Plan id
+     * @param  request  Required parameter: Request for updating a plan
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetPlanResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetPlanResponse deletePlan(
+    GetPlanResponse updatePlan(
             final String planId,
+            final UpdatePlanRequest request,
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
@@ -57,60 +59,6 @@ public interface PlansController {
     GetPlanResponse updatePlanMetadata(
             final String planId,
             final UpdateMetadataRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Updates a plan item.
-     * @param  planId  Required parameter: Plan id
-     * @param  planItemId  Required parameter: Plan item id
-     * @param  body  Required parameter: Request for updating the plan item
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetPlanItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetPlanItemResponse updatePlanItem(
-            final String planId,
-            final String planItemId,
-            final UpdatePlanItemRequest body,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Adds a new item to a plan.
-     * @param  planId  Required parameter: Plan id
-     * @param  request  Required parameter: Request for creating a plan item
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetPlanItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetPlanItemResponse createPlanItem(
-            final String planId,
-            final CreatePlanItemRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Gets a plan item.
-     * @param  planId  Required parameter: Plan id
-     * @param  planItemId  Required parameter: Plan item id
-     * @return    Returns the GetPlanItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetPlanItemResponse getPlanItem(
-            final String planId,
-            final String planItemId) throws ApiException, IOException;
-
-    /**
-     * Creates a new plan.
-     * @param  body  Required parameter: Request for creating a plan
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetPlanResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetPlanResponse createPlan(
-            final CreatePlanRequest body,
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
@@ -150,17 +98,69 @@ public interface PlansController {
             final LocalDateTime createdUntil) throws ApiException, IOException;
 
     /**
-     * Updates a plan.
+     * Gets a plan item.
      * @param  planId  Required parameter: Plan id
-     * @param  request  Required parameter: Request for updating a plan
+     * @param  planItemId  Required parameter: Plan item id
+     * @return    Returns the GetPlanItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetPlanItemResponse getPlanItem(
+            final String planId,
+            final String planItemId) throws ApiException, IOException;
+
+    /**
+     * Deletes a plan.
+     * @param  planId  Required parameter: Plan id
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetPlanResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetPlanResponse updatePlan(
+    GetPlanResponse deletePlan(
             final String planId,
-            final UpdatePlanRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Updates a plan item.
+     * @param  planId  Required parameter: Plan id
+     * @param  planItemId  Required parameter: Plan item id
+     * @param  body  Required parameter: Request for updating the plan item
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetPlanItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetPlanItemResponse updatePlanItem(
+            final String planId,
+            final String planItemId,
+            final UpdatePlanItemRequest body,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Adds a new item to a plan.
+     * @param  planId  Required parameter: Plan id
+     * @param  request  Required parameter: Request for creating a plan item
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetPlanItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetPlanItemResponse createPlanItem(
+            final String planId,
+            final CreatePlanItemRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Creates a new plan.
+     * @param  body  Required parameter: Request for creating a plan
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetPlanResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetPlanResponse createPlan(
+            final CreatePlanRequest body,
             final String idempotencyKey) throws ApiException, IOException;
 
 }

--- a/src/main/java/me/pagar/api/controllers/RecipientsController.java
+++ b/src/main/java/me/pagar/api/controllers/RecipientsController.java
@@ -89,31 +89,6 @@ public interface RecipientsController {
             final Integer size) throws ApiException, IOException;
 
     /**
-     * @param  recipientId  Required parameter: Example:
-     * @param  withdrawalId  Required parameter: Example:
-     * @return    Returns the GetWithdrawResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetWithdrawResponse getWithdrawById(
-            final String recipientId,
-            final String withdrawalId) throws ApiException, IOException;
-
-    /**
-     * Updates the default bank account from a recipient.
-     * @param  recipientId  Required parameter: Recipient id
-     * @param  request  Required parameter: Bank account data
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetRecipientResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetRecipientResponse updateRecipientDefaultBankAccount(
-            final String recipientId,
-            final UpdateRecipientBankAccountRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
      * Updates recipient metadata.
      * @param  recipientId  Required parameter: Recipient id
      * @param  request  Required parameter: Metadata
@@ -128,26 +103,6 @@ public interface RecipientsController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
-     * Gets a paginated list of transfers for the recipient.
-     * @param  recipientId  Required parameter: Recipient id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @param  status  Optional parameter: Filter for transfer status
-     * @param  createdSince  Optional parameter: Filter for start range of transfer creation date
-     * @param  createdUntil  Optional parameter: Filter for end range of transfer creation date
-     * @return    Returns the ListTransferResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    ListTransferResponse getTransfers(
-            final String recipientId,
-            final Integer page,
-            final Integer size,
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) throws ApiException, IOException;
-
-    /**
      * Gets a transfer.
      * @param  recipientId  Required parameter: Recipient id
      * @param  transferId  Required parameter: Transfer id
@@ -158,31 +113,6 @@ public interface RecipientsController {
     GetTransferResponse getTransfer(
             final String recipientId,
             final String transferId) throws ApiException, IOException;
-
-    /**
-     * @param  recipientId  Required parameter: Example:
-     * @param  request  Required parameter: Example:
-     * @return    Returns the GetWithdrawResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetWithdrawResponse createWithdraw(
-            final String recipientId,
-            final CreateWithdrawRequest request) throws ApiException, IOException;
-
-    /**
-     * Updates recipient metadata.
-     * @param  recipientId  Required parameter: Recipient id
-     * @param  request  Required parameter: Metadata
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetRecipientResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetRecipientResponse updateAutomaticAnticipationSettings(
-            final String recipientId,
-            final UpdateAutomaticAnticipationSettingsRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
 
     /**
      * Gets an anticipation.
@@ -239,14 +169,29 @@ public interface RecipientsController {
             final LocalDateTime createdUntil) throws ApiException, IOException;
 
     /**
-     * Retrieves recipient information.
-     * @param  recipientId  Required parameter: Recipiend id
+     * Updates the default bank account from a recipient.
+     * @param  recipientId  Required parameter: Recipient id
+     * @param  request  Required parameter: Bank account data
+     * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetRecipientResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetRecipientResponse getRecipient(
-            final String recipientId) throws ApiException, IOException;
+    GetRecipientResponse updateRecipientDefaultBankAccount(
+            final String recipientId,
+            final UpdateRecipientBankAccountRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * @param  recipientId  Required parameter: Example:
+     * @param  request  Required parameter: Example:
+     * @return    Returns the GetWithdrawResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetWithdrawResponse createWithdraw(
+            final String recipientId,
+            final CreateWithdrawRequest request) throws ApiException, IOException;
 
     /**
      * Get balance information for a recipient.
@@ -257,26 +202,6 @@ public interface RecipientsController {
      */
     GetBalanceResponse getBalance(
             final String recipientId) throws ApiException, IOException;
-
-    /**
-     * Gets a paginated list of transfers for the recipient.
-     * @param  recipientId  Required parameter: Example:
-     * @param  page  Optional parameter: Example:
-     * @param  size  Optional parameter: Example:
-     * @param  status  Optional parameter: Example:
-     * @param  createdSince  Optional parameter: Example:
-     * @param  createdUntil  Optional parameter: Example:
-     * @return    Returns the ListWithdrawals response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    ListWithdrawals getWithdrawals(
-            final String recipientId,
-            final Integer page,
-            final Integer size,
-            final String status,
-            final LocalDateTime createdSince,
-            final LocalDateTime createdUntil) throws ApiException, IOException;
 
     /**
      * Creates a transfer for a recipient.
@@ -303,6 +228,81 @@ public interface RecipientsController {
     GetRecipientResponse createRecipient(
             final CreateRecipientRequest request,
             final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Updates recipient metadata.
+     * @param  recipientId  Required parameter: Recipient id
+     * @param  request  Required parameter: Metadata
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetRecipientResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetRecipientResponse updateAutomaticAnticipationSettings(
+            final String recipientId,
+            final UpdateAutomaticAnticipationSettingsRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Retrieves recipient information.
+     * @param  recipientId  Required parameter: Recipiend id
+     * @return    Returns the GetRecipientResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetRecipientResponse getRecipient(
+            final String recipientId) throws ApiException, IOException;
+
+    /**
+     * Gets a paginated list of transfers for the recipient.
+     * @param  recipientId  Required parameter: Example:
+     * @param  page  Optional parameter: Example:
+     * @param  size  Optional parameter: Example:
+     * @param  status  Optional parameter: Example:
+     * @param  createdSince  Optional parameter: Example:
+     * @param  createdUntil  Optional parameter: Example:
+     * @return    Returns the ListWithdrawals response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListWithdrawals getWithdrawals(
+            final String recipientId,
+            final Integer page,
+            final Integer size,
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) throws ApiException, IOException;
+
+    /**
+     * @param  recipientId  Required parameter: Example:
+     * @param  withdrawalId  Required parameter: Example:
+     * @return    Returns the GetWithdrawResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetWithdrawResponse getWithdrawById(
+            final String recipientId,
+            final String withdrawalId) throws ApiException, IOException;
+
+    /**
+     * Gets a paginated list of transfers for the recipient.
+     * @param  recipientId  Required parameter: Recipient id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @param  status  Optional parameter: Filter for transfer status
+     * @param  createdSince  Optional parameter: Filter for start range of transfer creation date
+     * @param  createdUntil  Optional parameter: Filter for end range of transfer creation date
+     * @return    Returns the ListTransferResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListTransferResponse getTransfers(
+            final String recipientId,
+            final Integer page,
+            final Integer size,
+            final String status,
+            final LocalDateTime createdSince,
+            final LocalDateTime createdUntil) throws ApiException, IOException;
 
     /**
      * Retrieves recipient information.

--- a/src/main/java/me/pagar/api/controllers/SubscriptionsController.java
+++ b/src/main/java/me/pagar/api/controllers/SubscriptionsController.java
@@ -57,77 +57,6 @@ public interface SubscriptionsController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
-     * Updates the credit card from a subscription.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for updating a card
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionResponse updateSubscriptionCard(
-            final String subscriptionId,
-            final UpdateSubscriptionCardRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Deletes a usage.
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  itemId  Required parameter: The subscription item id
-     * @param  usageId  Required parameter: The usage id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetUsageResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetUsageResponse deleteUsage(
-            final String subscriptionId,
-            final String itemId,
-            final String usageId,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Creates a discount.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for creating a discount
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetDiscountResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetDiscountResponse createDiscount(
-            final String subscriptionId,
-            final CreateDiscountRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Create Usage.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  itemId  Required parameter: Item id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetUsageResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetUsageResponse createAnUsage(
-            final String subscriptionId,
-            final String itemId,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  request  Required parameter: Request for updating the end date of the subscription
-     *         current status
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    void updateCurrentCycleStatus(
-            final String subscriptionId,
-            final UpdateCurrentCycleStatusRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
      * Deletes a discount.
      * @param  subscriptionId  Required parameter: Subscription id
      * @param  discountId  Required parameter: Discount Id
@@ -140,59 +69,6 @@ public interface SubscriptionsController {
             final String subscriptionId,
             final String discountId,
             final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Get Subscription Items.
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @param  name  Optional parameter: The item name
-     * @param  code  Optional parameter: Identification code in the client system
-     * @param  status  Optional parameter: The item statis
-     * @param  description  Optional parameter: The item description
-     * @param  createdSince  Optional parameter: Filter for item's creation date start range
-     * @param  createdUntil  Optional parameter: Filter for item's creation date end range
-     * @return    Returns the ListSubscriptionItemsResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    ListSubscriptionItemsResponse getSubscriptionItems(
-            final String subscriptionId,
-            final Integer page,
-            final Integer size,
-            final String name,
-            final String code,
-            final String status,
-            final String description,
-            final String createdSince,
-            final String createdUntil) throws ApiException, IOException;
-
-    /**
-     * Updates the payment method from a subscription.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for updating the paymentmethod from a
-     *         subscription
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionResponse updateSubscriptionPaymentMethod(
-            final String subscriptionId,
-            final UpdateSubscriptionPaymentMethodRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Get Subscription Item.
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  itemId  Required parameter: Item id
-     * @return    Returns the GetSubscriptionItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionItemResponse getSubscriptionItem(
-            final String subscriptionId,
-            final String itemId) throws ApiException, IOException;
 
     /**
      * Gets all subscriptions.
@@ -229,50 +105,6 @@ public interface SubscriptionsController {
             final LocalDateTime createdUntil) throws ApiException, IOException;
 
     /**
-     * Cancels a subscription.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Optional parameter: Request for cancelling a subscription
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionResponse cancelSubscription(
-            final String subscriptionId,
-            final CreateCancelSubscriptionRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Creates a increment.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for creating a increment
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetIncrementResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetIncrementResponse createIncrement(
-            final String subscriptionId,
-            final CreateIncrementRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Creates a usage.
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  itemId  Required parameter: Item id
-     * @param  body  Required parameter: Request for creating a usage
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetUsageResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetUsageResponse createUsage(
-            final String subscriptionId,
-            final String itemId,
-            final CreateUsageRequest body,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
      * @param  subscriptionId  Required parameter: The subscription id
      * @param  discountId  Required parameter: Example:
      * @return    Returns the GetDiscountResponse response from the API call
@@ -307,19 +139,6 @@ public interface SubscriptionsController {
             final String incrementId) throws ApiException, IOException;
 
     /**
-     * @param  subscriptionId  Required parameter: Example:
-     * @param  request  Required parameter: Request for updating a subscription affiliation id
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionResponse updateSubscriptionAffiliationId(
-            final String subscriptionId,
-            final UpdateSubscriptionAffiliationIdRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
      * Updates the metadata from a subscription.
      * @param  subscriptionId  Required parameter: The subscription id
      * @param  request  Required parameter: Request for updating the subscrption metadata
@@ -348,17 +167,92 @@ public interface SubscriptionsController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  page  Required parameter: Page number
-     * @param  size  Required parameter: Page size
-     * @return    Returns the ListCyclesResponse response from the API call
+     * Gets a subscription.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @return    Returns the GetSubscriptionResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    ListCyclesResponse getSubscriptionCycles(
+    GetSubscriptionResponse getSubscription(
+            final String subscriptionId) throws ApiException, IOException;
+
+    /**
+     * @param  subscriptionId  Required parameter: Example:
+     * @param  request  Required parameter: Request for updating the end date of the current
+     *         signature cycle
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionResponse updateLatestPeriodEndAt(
             final String subscriptionId,
-            final String page,
-            final String size) throws ApiException, IOException;
+            final UpdateCurrentCycleEndDateRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  request  Required parameter: Request for updating the end date of the subscription
+     *         current status
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    void updateCurrentCycleStatus(
+            final String subscriptionId,
+            final UpdateCurrentCycleStatusRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Get Subscription Items.
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @param  name  Optional parameter: The item name
+     * @param  code  Optional parameter: Identification code in the client system
+     * @param  status  Optional parameter: The item statis
+     * @param  description  Optional parameter: The item description
+     * @param  createdSince  Optional parameter: Filter for item's creation date start range
+     * @param  createdUntil  Optional parameter: Filter for item's creation date end range
+     * @return    Returns the ListSubscriptionItemsResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListSubscriptionItemsResponse getSubscriptionItems(
+            final String subscriptionId,
+            final Integer page,
+            final Integer size,
+            final String name,
+            final String code,
+            final String status,
+            final String description,
+            final String createdSince,
+            final String createdUntil) throws ApiException, IOException;
+
+    /**
+     * Get Subscription Item.
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  itemId  Required parameter: Item id
+     * @return    Returns the GetSubscriptionItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionItemResponse getSubscriptionItem(
+            final String subscriptionId,
+            final String itemId) throws ApiException, IOException;
+
+    /**
+     * @param  subscriptionId  Required parameter: Example:
+     * @param  request  Required parameter: Request for updating a subscription affiliation id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionResponse updateSubscriptionAffiliationId(
+            final String subscriptionId,
+            final UpdateSubscriptionAffiliationIdRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
 
     /**
      * @param  subscriptionId  Required parameter: The subscription id
@@ -374,17 +268,111 @@ public interface SubscriptionsController {
             final int size) throws ApiException, IOException;
 
     /**
-     * Updates the billing date from a subscription.
+     * Updates a subscription item.
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  itemId  Required parameter: Item id
+     * @param  body  Required parameter: Request for updating a subscription item
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionItemResponse updateSubscriptionItem(
+            final String subscriptionId,
+            final String itemId,
+            final UpdateSubscriptionItemRequest body,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Creates a new Subscription item.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for creating a subscription item
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionItemResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionItemResponse createSubscriptionItem(
+            final String subscriptionId,
+            final CreateSubscriptionItemRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Lists all usages from a subscription item.
      * @param  subscriptionId  Required parameter: The subscription id
-     * @param  request  Required parameter: Request for updating the subscription billing date
+     * @param  itemId  Required parameter: The subscription item id
+     * @param  page  Optional parameter: Page number
+     * @param  size  Optional parameter: Page size
+     * @param  code  Optional parameter: Identification code in the client system
+     * @param  group  Optional parameter: Identification group in the client system
+     * @param  usedSince  Optional parameter: Example:
+     * @param  usedUntil  Optional parameter: Example:
+     * @return    Returns the ListUsagesResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListUsagesResponse getUsages(
+            final String subscriptionId,
+            final String itemId,
+            final Integer page,
+            final Integer size,
+            final String code,
+            final String group,
+            final LocalDateTime usedSince,
+            final LocalDateTime usedUntil) throws ApiException, IOException;
+
+    /**
+     * Atualização do valor mínimo da assinatura.
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  request  Required parameter: Request da requisição com o valor mínimo que será
+     *         configurado
      * @param  idempotencyKey  Optional parameter: Example:
      * @return    Returns the GetSubscriptionResponse response from the API call
      * @throws    ApiException    Represents error response from the server.
      * @throws    IOException    Signals that an I/O exception of some sort has occurred.
      */
-    GetSubscriptionResponse updateSubscriptionBillingDate(
+    GetSubscriptionResponse updateSubscriptionMiniumPrice(
             final String subscriptionId,
-            final UpdateSubscriptionBillingDateRequest request,
+            final UpdateSubscriptionMinimumPriceRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  cycleId  Required parameter: Example:
+     * @return    Returns the GetPeriodResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetPeriodResponse getSubscriptionCycleById(
+            final String subscriptionId,
+            final String cycleId) throws ApiException, IOException;
+
+    /**
+     * Create Usage.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  itemId  Required parameter: Item id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetUsageResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetUsageResponse createAnUsage(
+            final String subscriptionId,
+            final String itemId,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Cancels a subscription.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Optional parameter: Request for cancelling a subscription
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionResponse cancelSubscription(
+            final String subscriptionId,
+            final CreateCancelSubscriptionRequest request,
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
@@ -429,6 +417,122 @@ public interface SubscriptionsController {
             final String idempotencyKey) throws ApiException, IOException;
 
     /**
+     * Updates the credit card from a subscription.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for updating a card
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionResponse updateSubscriptionCard(
+            final String subscriptionId,
+            final UpdateSubscriptionCardRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Deletes a usage.
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  itemId  Required parameter: The subscription item id
+     * @param  usageId  Required parameter: The usage id
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetUsageResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetUsageResponse deleteUsage(
+            final String subscriptionId,
+            final String itemId,
+            final String usageId,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Creates a discount.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for creating a discount
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetDiscountResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetDiscountResponse createDiscount(
+            final String subscriptionId,
+            final CreateDiscountRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Updates the payment method from a subscription.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for updating the paymentmethod from a
+     *         subscription
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionResponse updateSubscriptionPaymentMethod(
+            final String subscriptionId,
+            final UpdateSubscriptionPaymentMethodRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Creates a increment.
+     * @param  subscriptionId  Required parameter: Subscription id
+     * @param  request  Required parameter: Request for creating a increment
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetIncrementResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetIncrementResponse createIncrement(
+            final String subscriptionId,
+            final CreateIncrementRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * Creates a usage.
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  itemId  Required parameter: Item id
+     * @param  body  Required parameter: Request for creating a usage
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetUsageResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetUsageResponse createUsage(
+            final String subscriptionId,
+            final String itemId,
+            final CreateUsageRequest body,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
+     * @param  subscriptionId  Required parameter: Subscription Id
+     * @param  page  Required parameter: Page number
+     * @param  size  Required parameter: Page size
+     * @return    Returns the ListCyclesResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListCyclesResponse getSubscriptionCycles(
+            final String subscriptionId,
+            final String page,
+            final String size) throws ApiException, IOException;
+
+    /**
+     * Updates the billing date from a subscription.
+     * @param  subscriptionId  Required parameter: The subscription id
+     * @param  request  Required parameter: Request for updating the subscription billing date
+     * @param  idempotencyKey  Optional parameter: Example:
+     * @return    Returns the GetSubscriptionResponse response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    GetSubscriptionResponse updateSubscriptionBillingDate(
+            final String subscriptionId,
+            final UpdateSubscriptionBillingDateRequest request,
+            final String idempotencyKey) throws ApiException, IOException;
+
+    /**
      * Updates the start at date from a subscription.
      * @param  subscriptionId  Required parameter: The subscription id
      * @param  request  Required parameter: Request for updating the subscription start date
@@ -441,110 +545,6 @@ public interface SubscriptionsController {
             final String subscriptionId,
             final UpdateSubscriptionStartAtRequest request,
             final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Updates a subscription item.
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  itemId  Required parameter: Item id
-     * @param  body  Required parameter: Request for updating a subscription item
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionItemResponse updateSubscriptionItem(
-            final String subscriptionId,
-            final String itemId,
-            final UpdateSubscriptionItemRequest body,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Creates a new Subscription item.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @param  request  Required parameter: Request for creating a subscription item
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionItemResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionItemResponse createSubscriptionItem(
-            final String subscriptionId,
-            final CreateSubscriptionItemRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Gets a subscription.
-     * @param  subscriptionId  Required parameter: Subscription id
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionResponse getSubscription(
-            final String subscriptionId) throws ApiException, IOException;
-
-    /**
-     * Lists all usages from a subscription item.
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  itemId  Required parameter: The subscription item id
-     * @param  page  Optional parameter: Page number
-     * @param  size  Optional parameter: Page size
-     * @param  code  Optional parameter: Identification code in the client system
-     * @param  group  Optional parameter: Identification group in the client system
-     * @param  usedSince  Optional parameter: Example:
-     * @param  usedUntil  Optional parameter: Example:
-     * @return    Returns the ListUsagesResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    ListUsagesResponse getUsages(
-            final String subscriptionId,
-            final String itemId,
-            final Integer page,
-            final Integer size,
-            final String code,
-            final String group,
-            final LocalDateTime usedSince,
-            final LocalDateTime usedUntil) throws ApiException, IOException;
-
-    /**
-     * @param  subscriptionId  Required parameter: Example:
-     * @param  request  Required parameter: Request for updating the end date of the current
-     *         signature cycle
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionResponse updateLatestPeriodEndAt(
-            final String subscriptionId,
-            final UpdateCurrentCycleEndDateRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * Atualização do valor mínimo da assinatura.
-     * @param  subscriptionId  Required parameter: Subscription Id
-     * @param  request  Required parameter: Request da requisição com o valor mínimo que será
-     *         configurado
-     * @param  idempotencyKey  Optional parameter: Example:
-     * @return    Returns the GetSubscriptionResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetSubscriptionResponse updateSubscriptionMiniumPrice(
-            final String subscriptionId,
-            final UpdateSubscriptionMinimumPriceRequest request,
-            final String idempotencyKey) throws ApiException, IOException;
-
-    /**
-     * @param  subscriptionId  Required parameter: The subscription id
-     * @param  cycleId  Required parameter: Example:
-     * @return    Returns the GetPeriodResponse response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    GetPeriodResponse getSubscriptionCycleById(
-            final String subscriptionId,
-            final String cycleId) throws ApiException, IOException;
 
     /**
      * @param  subscriptionId  Required parameter: The subscription Id

--- a/src/main/java/me/pagar/api/controllers/TransfersController.java
+++ b/src/main/java/me/pagar/api/controllers/TransfersController.java
@@ -18,6 +18,14 @@ import me.pagar.api.models.ListTransfers;
  */
 public interface TransfersController {
     /**
+     * Gets all transfers.
+     * @return    Returns the ListTransfers response from the API call
+     * @throws    ApiException    Represents error response from the server.
+     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
+     */
+    ListTransfers getTransfers() throws ApiException, IOException;
+
+    /**
      * @param  transferId  Required parameter: Example:
      * @return    Returns the GetTransfer response from the API call
      * @throws    ApiException    Represents error response from the server.
@@ -34,13 +42,5 @@ public interface TransfersController {
      */
     GetTransfer createTransfer(
             final CreateTransfer request) throws ApiException, IOException;
-
-    /**
-     * Gets all transfers.
-     * @return    Returns the ListTransfers response from the API call
-     * @throws    ApiException    Represents error response from the server.
-     * @throws    IOException    Signals that an I/O exception of some sort has occurred.
-     */
-    ListTransfers getTransfers() throws ApiException, IOException;
 
 }

--- a/src/main/java/me/pagar/api/models/CreateOrderItemRequest.java
+++ b/src/main/java/me/pagar/api/models/CreateOrderItemRequest.java
@@ -17,10 +17,6 @@ public class CreateOrderItemRequest {
     private int amount;
     private String description;
     private int quantity;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private CreateSellerRequest seller;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String sellerId;
     private String category;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String code;
@@ -37,8 +33,6 @@ public class CreateOrderItemRequest {
      * @param  description  String value for description.
      * @param  quantity  int value for quantity.
      * @param  category  String value for category.
-     * @param  seller  CreateSellerRequest value for seller.
-     * @param  sellerId  String value for sellerId.
      * @param  code  String value for code.
      */
     public CreateOrderItemRequest(
@@ -46,14 +40,10 @@ public class CreateOrderItemRequest {
             String description,
             int quantity,
             String category,
-            CreateSellerRequest seller,
-            String sellerId,
             String code) {
         this.amount = amount;
         this.description = description;
         this.quantity = quantity;
-        this.seller = seller;
-        this.sellerId = sellerId;
         this.category = category;
         this.code = code;
     }
@@ -119,46 +109,6 @@ public class CreateOrderItemRequest {
     }
 
     /**
-     * Getter for Seller.
-     * Item seller
-     * @return Returns the CreateSellerRequest
-     */
-    @JsonGetter("seller")
-    public CreateSellerRequest getSeller() {
-        return seller;
-    }
-
-    /**
-     * Setter for Seller.
-     * Item seller
-     * @param seller Value for CreateSellerRequest
-     */
-    @JsonSetter("seller")
-    public void setSeller(CreateSellerRequest seller) {
-        this.seller = seller;
-    }
-
-    /**
-     * Getter for SellerId.
-     * seller identificator
-     * @return Returns the String
-     */
-    @JsonGetter("seller_id")
-    public String getSellerId() {
-        return sellerId;
-    }
-
-    /**
-     * Setter for SellerId.
-     * seller identificator
-     * @param sellerId Value for String
-     */
-    @JsonSetter("seller_id")
-    public void setSellerId(String sellerId) {
-        this.sellerId = sellerId;
-    }
-
-    /**
      * Getter for Category.
      * Category
      * @return Returns the String
@@ -205,8 +155,7 @@ public class CreateOrderItemRequest {
     @Override
     public String toString() {
         return "CreateOrderItemRequest [" + "amount=" + amount + ", description=" + description
-                + ", quantity=" + quantity + ", category=" + category + ", seller=" + seller
-                + ", sellerId=" + sellerId + ", code=" + code + "]";
+                + ", quantity=" + quantity + ", category=" + category + ", code=" + code + "]";
     }
 
     /**
@@ -216,8 +165,6 @@ public class CreateOrderItemRequest {
      */
     public Builder toBuilder() {
         Builder builder = new Builder(amount, description, quantity, category)
-                .seller(getSeller())
-                .sellerId(getSellerId())
                 .code(getCode());
         return builder;
     }
@@ -230,8 +177,6 @@ public class CreateOrderItemRequest {
         private String description;
         private int quantity;
         private String category;
-        private CreateSellerRequest seller;
-        private String sellerId;
         private String code;
 
         /**
@@ -295,26 +240,6 @@ public class CreateOrderItemRequest {
         }
 
         /**
-         * Setter for seller.
-         * @param  seller  CreateSellerRequest value for seller.
-         * @return Builder
-         */
-        public Builder seller(CreateSellerRequest seller) {
-            this.seller = seller;
-            return this;
-        }
-
-        /**
-         * Setter for sellerId.
-         * @param  sellerId  String value for sellerId.
-         * @return Builder
-         */
-        public Builder sellerId(String sellerId) {
-            this.sellerId = sellerId;
-            return this;
-        }
-
-        /**
          * Setter for code.
          * @param  code  String value for code.
          * @return Builder
@@ -329,8 +254,7 @@ public class CreateOrderItemRequest {
          * @return {@link CreateOrderItemRequest}
          */
         public CreateOrderItemRequest build() {
-            return new CreateOrderItemRequest(amount, description, quantity, category, seller,
-                    sellerId, code);
+            return new CreateOrderItemRequest(amount, description, quantity, category, code);
         }
     }
 }

--- a/src/main/java/me/pagar/api/models/GetOrderItemResponse.java
+++ b/src/main/java/me/pagar/api/models/GetOrderItemResponse.java
@@ -7,7 +7,6 @@
 package me.pagar.api.models;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 /**
@@ -18,8 +17,6 @@ public class GetOrderItemResponse {
     private int amount;
     private String description;
     private int quantity;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private GetSellerResponse getSellerResponse;
     private String category;
     private String code;
 
@@ -37,7 +34,6 @@ public class GetOrderItemResponse {
      * @param  quantity  int value for quantity.
      * @param  category  String value for category.
      * @param  code  String value for code.
-     * @param  getSellerResponse  GetSellerResponse value for getSellerResponse.
      */
     public GetOrderItemResponse(
             String id,
@@ -45,13 +41,11 @@ public class GetOrderItemResponse {
             String description,
             int quantity,
             String category,
-            String code,
-            GetSellerResponse getSellerResponse) {
+            String code) {
         this.id = id;
         this.amount = amount;
         this.description = description;
         this.quantity = quantity;
-        this.getSellerResponse = getSellerResponse;
         this.category = category;
         this.code = code;
     }
@@ -131,26 +125,6 @@ public class GetOrderItemResponse {
     }
 
     /**
-     * Getter for GetSellerResponse.
-     * Seller data
-     * @return Returns the GetSellerResponse
-     */
-    @JsonGetter("GetSellerResponse")
-    public GetSellerResponse getGetSellerResponse() {
-        return getSellerResponse;
-    }
-
-    /**
-     * Setter for GetSellerResponse.
-     * Seller data
-     * @param getSellerResponse Value for GetSellerResponse
-     */
-    @JsonSetter("GetSellerResponse")
-    public void setGetSellerResponse(GetSellerResponse getSellerResponse) {
-        this.getSellerResponse = getSellerResponse;
-    }
-
-    /**
      * Getter for Category.
      * Category
      * @return Returns the String
@@ -198,7 +172,7 @@ public class GetOrderItemResponse {
     public String toString() {
         return "GetOrderItemResponse [" + "id=" + id + ", amount=" + amount + ", description="
                 + description + ", quantity=" + quantity + ", category=" + category + ", code="
-                + code + ", getSellerResponse=" + getSellerResponse + "]";
+                + code + "]";
     }
 
     /**
@@ -207,8 +181,7 @@ public class GetOrderItemResponse {
      * @return a new {@link GetOrderItemResponse.Builder} object
      */
     public Builder toBuilder() {
-        Builder builder = new Builder(id, amount, description, quantity, category, code)
-                .getSellerResponse(getGetSellerResponse());
+        Builder builder = new Builder(id, amount, description, quantity, category, code);
         return builder;
     }
 
@@ -222,7 +195,6 @@ public class GetOrderItemResponse {
         private int quantity;
         private String category;
         private String code;
-        private GetSellerResponse getSellerResponse;
 
         /**
          * Initialization constructor.
@@ -310,22 +282,11 @@ public class GetOrderItemResponse {
         }
 
         /**
-         * Setter for getSellerResponse.
-         * @param  getSellerResponse  GetSellerResponse value for getSellerResponse.
-         * @return Builder
-         */
-        public Builder getSellerResponse(GetSellerResponse getSellerResponse) {
-            this.getSellerResponse = getSellerResponse;
-            return this;
-        }
-
-        /**
          * Builds a new {@link GetOrderItemResponse} object using the set fields.
          * @return {@link GetOrderItemResponse}
          */
         public GetOrderItemResponse build() {
-            return new GetOrderItemResponse(id, amount, description, quantity, category, code,
-                    getSellerResponse);
+            return new GetOrderItemResponse(id, amount, description, quantity, category, code);
         }
     }
 }

--- a/src/main/java/me/pagar/api/models/GetTransactionResponse.java
+++ b/src/main/java/me/pagar/api/models/GetTransactionResponse.java
@@ -30,15 +30,15 @@ import me.pagar.api.DateTimeHelper;
         defaultImpl = GetTransactionResponse.class,
         visible = true)
 @JsonSubTypes({
+    @Type(value = GetVoucherTransactionResponse.class, name = "voucher"),
     @Type(value = GetBankTransferTransactionResponse.class, name = "bank_transfer"),
     @Type(value = GetSafetyPayTransactionResponse.class, name = "safetypay"),
-    @Type(value = GetVoucherTransactionResponse.class, name = "voucher"),
-    @Type(value = GetBoletoTransactionResponse.class, name = "boleto"),
     @Type(value = GetDebitCardTransactionResponse.class, name = "debit_card"),
-    @Type(value = GetPrivateLabelTransactionResponse.class, name = "private_label"),
+    @Type(value = GetBoletoTransactionResponse.class, name = "boleto"),
     @Type(value = GetCashTransactionResponse.class, name = "cash"),
-    @Type(value = GetCreditCardTransactionResponse.class, name = "credit_card"),
-    @Type(value = GetPixTransactionResponse.class, name = "pix")
+    @Type(value = GetPrivateLabelTransactionResponse.class, name = "private_label"),
+    @Type(value = GetPixTransactionResponse.class, name = "pix"),
+    @Type(value = GetCreditCardTransactionResponse.class, name = "credit_card")
 })
 @JsonInclude(Include.ALWAYS)
 public class GetTransactionResponse {


### PR DESCRIPTION
The customer should no longer use the Mark1 Sellers endpoint as it is outdated. We need to remove it from the SDK so it no longer has access.